### PR TITLE
feat(ui): add layout components (TASK-034-039)

### DIFF
--- a/src/components/ui/layout/Container/Container.stories.tsx
+++ b/src/components/ui/layout/Container/Container.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Container } from './Container'
+
+const meta: Meta<typeof Container> = {
+  title: 'UI/Layout/Container',
+  component: Container,
+  tags: ['autodocs'],
+  args: {
+    children: (
+      <div className="bg-blue-50 border border-blue-200 p-4 rounded text-blue-700 text-sm text-center">
+        Container content
+      </div>
+    ),
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Container>
+
+export const Default: Story = {}
+export const Small: Story = { args: { maxWidth: 'sm' } }
+export const Medium: Story = { args: { maxWidth: 'md' } }
+export const Large: Story = { args: { maxWidth: 'lg' } }
+export const ExtraLarge: Story = { args: { maxWidth: 'xl' } }
+export const Full: Story = { args: { maxWidth: 'full' } }

--- a/src/components/ui/layout/Container/Container.test.tsx
+++ b/src/components/ui/layout/Container/Container.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Container } from './Container'
+
+describe('Container', () => {
+  it('renders children', () => {
+    render(<Container>content</Container>)
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+
+  it('applies default xl max-width', () => {
+    const { container } = render(<Container>content</Container>)
+    expect(container.firstChild).toHaveClass('max-w-screen-xl')
+  })
+
+  it('applies lg max-width', () => {
+    const { container } = render(<Container maxWidth="lg">content</Container>)
+    expect(container.firstChild).toHaveClass('max-w-screen-lg')
+  })
+
+  it('applies sm max-width', () => {
+    const { container } = render(<Container maxWidth="sm">content</Container>)
+    expect(container.firstChild).toHaveClass('max-w-screen-sm')
+  })
+
+  it('applies full max-width', () => {
+    const { container } = render(<Container maxWidth="full">content</Container>)
+    expect(container.firstChild).toHaveClass('max-w-full')
+  })
+
+  it('applies 2xl max-width', () => {
+    const { container } = render(<Container maxWidth="2xl">content</Container>)
+    expect(container.firstChild).toHaveClass('max-w-screen-2xl')
+  })
+
+  it('applies centering and padding classes', () => {
+    const { container } = render(<Container>content</Container>)
+    expect(container.firstChild).toHaveClass('mx-auto', 'px-4', 'w-full')
+  })
+
+  it('applies additional className', () => {
+    const { container } = render(<Container className="extra">content</Container>)
+    expect(container.firstChild).toHaveClass('extra')
+  })
+
+  it('forwards ref', () => {
+    const ref = vi.fn()
+    render(<Container ref={ref}>content</Container>)
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement))
+  })
+})

--- a/src/components/ui/layout/Container/Container.tsx
+++ b/src/components/ui/layout/Container/Container.tsx
@@ -1,0 +1,40 @@
+import { type HTMLAttributes, forwardRef } from 'react'
+import { cn } from '@/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+const containerVariants = cva('mx-auto w-full px-4', {
+  variants: {
+    maxWidth: {
+      sm: 'max-w-screen-sm',
+      md: 'max-w-screen-md',
+      lg: 'max-w-screen-lg',
+      xl: 'max-w-screen-xl',
+      '2xl': 'max-w-screen-2xl',
+      full: 'max-w-full',
+    },
+  },
+  defaultVariants: {
+    maxWidth: 'xl',
+  },
+})
+
+export interface ContainerProps
+  extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof containerVariants> {}
+
+/**
+ * Responsive container that centers content and constrains max-width.
+ *
+ * @example
+ * ```tsx
+ * <Container maxWidth="lg">
+ *   <p>Content</p>
+ * </Container>
+ * ```
+ */
+export const Container = forwardRef<HTMLDivElement, ContainerProps>(
+  ({ maxWidth, className, ...props }, ref) => (
+    <div ref={ref} className={cn(containerVariants({ maxWidth }), className)} {...props} />
+  )
+)
+
+Container.displayName = 'Container'

--- a/src/components/ui/layout/Container/index.ts
+++ b/src/components/ui/layout/Container/index.ts
@@ -1,0 +1,2 @@
+export { Container } from './Container'
+export type { ContainerProps } from './Container'

--- a/src/components/ui/layout/Divider/Divider.stories.tsx
+++ b/src/components/ui/layout/Divider/Divider.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Divider } from './Divider'
+
+const meta: Meta<typeof Divider> = {
+  title: 'UI/Layout/Divider',
+  component: Divider,
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof Divider>
+
+export const Horizontal: Story = {}
+
+export const Vertical: Story = {
+  args: { orientation: 'vertical' },
+  decorators: [
+    (Story) => (
+      <div className="flex h-12 items-center gap-4">
+        <span>Left</span>
+        <Story />
+        <span>Right</span>
+      </div>
+    ),
+  ],
+}
+
+export const WithLabel: Story = {
+  args: { label: 'OR' },
+}
+
+export const WithCustomLabel: Story = {
+  args: { label: 'Today' },
+}

--- a/src/components/ui/layout/Divider/Divider.test.tsx
+++ b/src/components/ui/layout/Divider/Divider.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Divider } from './Divider'
+
+describe('Divider', () => {
+  it('renders a horizontal separator by default', () => {
+    render(<Divider />)
+    expect(screen.getByRole('separator')).toBeInTheDocument()
+  })
+
+  it('renders an hr for horizontal', () => {
+    const { container } = render(<Divider />)
+    expect(container.querySelector('hr')).toBeInTheDocument()
+  })
+
+  it('renders a vertical separator', () => {
+    render(<Divider orientation="vertical" />)
+    const separator = screen.getByRole('separator')
+    expect(separator).toHaveAttribute('aria-orientation', 'vertical')
+  })
+
+  it('renders label text', () => {
+    render(<Divider label="OR" />)
+    expect(screen.getByText('OR')).toBeInTheDocument()
+  })
+
+  it('renders label divider as div with separator role', () => {
+    render(<Divider label="OR" />)
+    expect(screen.getByRole('separator')).toBeInTheDocument()
+  })
+
+  it('applies additional className', () => {
+    render(<Divider className="extra" />)
+    expect(screen.getByRole('separator')).toHaveClass('extra')
+  })
+
+  it('horizontal has border-t class', () => {
+    render(<Divider />)
+    expect(screen.getByRole('separator')).toHaveClass('border-t')
+  })
+
+  it('vertical has w-px class', () => {
+    render(<Divider orientation="vertical" />)
+    expect(screen.getByRole('separator')).toHaveClass('w-px')
+  })
+})

--- a/src/components/ui/layout/Divider/Divider.tsx
+++ b/src/components/ui/layout/Divider/Divider.tsx
@@ -1,0 +1,52 @@
+import { cn } from '@/lib/utils'
+
+export type DividerOrientation = 'horizontal' | 'vertical'
+
+export interface DividerProps {
+  /** Layout orientation */
+  orientation?: DividerOrientation
+  /** Optional label centered on the divider */
+  label?: string
+  /** Additional className */
+  className?: string
+}
+
+/**
+ * Visual separator between content sections.
+ *
+ * @example
+ * ```tsx
+ * <Divider />
+ * <Divider orientation="vertical" />
+ * <Divider label="OR" />
+ * ```
+ */
+export function Divider({ orientation = 'horizontal', label, className }: DividerProps) {
+  if (orientation === 'vertical') {
+    return (
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        className={cn('w-px bg-gray-200 self-stretch', className)}
+      />
+    )
+  }
+
+  if (label) {
+    return (
+      <div role="separator" className={cn('flex items-center gap-3', className)}>
+        <div className="flex-1 h-px bg-gray-200" />
+        <span className="text-xs text-gray-500 font-medium whitespace-nowrap">{label}</span>
+        <div className="flex-1 h-px bg-gray-200" />
+      </div>
+    )
+  }
+
+  return (
+    <hr
+      role="separator"
+      aria-orientation="horizontal"
+      className={cn('border-0 border-t border-gray-200', className)}
+    />
+  )
+}

--- a/src/components/ui/layout/Divider/index.ts
+++ b/src/components/ui/layout/Divider/index.ts
@@ -1,0 +1,2 @@
+export { Divider } from './Divider'
+export type { DividerProps, DividerOrientation } from './Divider'

--- a/src/components/ui/layout/Flex/Flex.stories.tsx
+++ b/src/components/ui/layout/Flex/Flex.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Flex } from './Flex'
+
+const meta: Meta<typeof Flex> = {
+  title: 'UI/Layout/Flex',
+  component: Flex,
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof Flex>
+
+function Box({ label }: { label: string }) {
+  return (
+    <div className="bg-primary-50 border border-primary-200 rounded px-3 py-2 text-primary-700 text-sm">
+      {label}
+    </div>
+  )
+}
+
+export const Row: Story = {
+  args: {
+    direction: 'row',
+    gap: 'md',
+    children: [1, 2, 3].map((n) => <Box key={n} label={`Item ${n}`} />),
+  },
+}
+
+export const Column: Story = {
+  args: {
+    direction: 'col',
+    gap: 'sm',
+    children: [1, 2, 3].map((n) => <Box key={n} label={`Item ${n}`} />),
+  },
+}
+
+export const CenterAligned: Story = {
+  args: {
+    direction: 'row',
+    align: 'center',
+    justify: 'between',
+    gap: 'md',
+    children: [<Box key={1} label="Logo" />, <Box key={2} label="Nav" />],
+  },
+}
+
+export const Wrapped: Story = {
+  args: {
+    wrap: 'wrap',
+    gap: 'sm',
+    children: [1, 2, 3, 4, 5, 6].map((n) => <Box key={n} label={`Tag ${n}`} />),
+  },
+}

--- a/src/components/ui/layout/Flex/Flex.test.tsx
+++ b/src/components/ui/layout/Flex/Flex.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Flex } from './Flex'
+
+describe('Flex', () => {
+  it('renders children', () => {
+    render(<Flex>content</Flex>)
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+
+  it('applies flex class', () => {
+    const { container } = render(<Flex>content</Flex>)
+    expect(container.firstChild).toHaveClass('flex')
+  })
+
+  it('applies default direction row', () => {
+    const { container } = render(<Flex>content</Flex>)
+    expect(container.firstChild).toHaveClass('flex-row')
+  })
+
+  it('applies column direction', () => {
+    const { container } = render(<Flex direction="col">content</Flex>)
+    expect(container.firstChild).toHaveClass('flex-col')
+  })
+
+  it('applies row-reverse direction', () => {
+    const { container } = render(<Flex direction="row-reverse">content</Flex>)
+    expect(container.firstChild).toHaveClass('flex-row-reverse')
+  })
+
+  it('applies center alignment', () => {
+    const { container } = render(<Flex align="center">content</Flex>)
+    expect(container.firstChild).toHaveClass('items-center')
+  })
+
+  it('applies justify-between', () => {
+    const { container } = render(<Flex justify="between">content</Flex>)
+    expect(container.firstChild).toHaveClass('justify-between')
+  })
+
+  it('applies gap', () => {
+    const { container } = render(<Flex gap="md">content</Flex>)
+    expect(container.firstChild).toHaveClass('gap-4')
+  })
+
+  it('applies wrap', () => {
+    const { container } = render(<Flex wrap="wrap">content</Flex>)
+    expect(container.firstChild).toHaveClass('flex-wrap')
+  })
+
+  it('applies additional className', () => {
+    const { container } = render(<Flex className="extra">content</Flex>)
+    expect(container.firstChild).toHaveClass('extra')
+  })
+
+  it('forwards ref', () => {
+    const ref = vi.fn()
+    render(<Flex ref={ref}>content</Flex>)
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement))
+  })
+})

--- a/src/components/ui/layout/Flex/Flex.tsx
+++ b/src/components/ui/layout/Flex/Flex.tsx
@@ -1,0 +1,75 @@
+import { type HTMLAttributes, forwardRef } from 'react'
+import { cn } from '@/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+const flexVariants = cva('flex', {
+  variants: {
+    direction: {
+      row: 'flex-row',
+      col: 'flex-col',
+      'row-reverse': 'flex-row-reverse',
+      'col-reverse': 'flex-col-reverse',
+    },
+    align: {
+      start: 'items-start',
+      center: 'items-center',
+      end: 'items-end',
+      stretch: 'items-stretch',
+      baseline: 'items-baseline',
+    },
+    justify: {
+      start: 'justify-start',
+      center: 'justify-center',
+      end: 'justify-end',
+      between: 'justify-between',
+      around: 'justify-around',
+      evenly: 'justify-evenly',
+    },
+    wrap: {
+      nowrap: 'flex-nowrap',
+      wrap: 'flex-wrap',
+      'wrap-reverse': 'flex-wrap-reverse',
+    },
+    gap: {
+      none: '',
+      xs: 'gap-1',
+      sm: 'gap-2',
+      md: 'gap-4',
+      lg: 'gap-6',
+      xl: 'gap-8',
+    },
+  },
+  defaultVariants: {
+    direction: 'row',
+    align: 'start',
+    justify: 'start',
+    wrap: 'nowrap',
+    gap: 'none',
+  },
+})
+
+export interface FlexProps
+  extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof flexVariants> {}
+
+/**
+ * Flexbox layout component with alignment and gap variants.
+ *
+ * @example
+ * ```tsx
+ * <Flex direction="row" align="center" justify="between" gap="md">
+ *   <Logo />
+ *   <Nav />
+ * </Flex>
+ * ```
+ */
+export const Flex = forwardRef<HTMLDivElement, FlexProps>(
+  ({ direction, align, justify, wrap, gap, className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(flexVariants({ direction, align, justify, wrap, gap }), className)}
+      {...props}
+    />
+  )
+)
+
+Flex.displayName = 'Flex'

--- a/src/components/ui/layout/Flex/index.ts
+++ b/src/components/ui/layout/Flex/index.ts
@@ -1,0 +1,2 @@
+export { Flex } from './Flex'
+export type { FlexProps } from './Flex'

--- a/src/components/ui/layout/Grid/Grid.stories.tsx
+++ b/src/components/ui/layout/Grid/Grid.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Grid } from './Grid'
+
+const meta: Meta<typeof Grid> = {
+  title: 'UI/Layout/Grid',
+  component: Grid,
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof Grid>
+
+function Box({ label }: { label: string }) {
+  return (
+    <div className="bg-primary-50 border border-primary-200 rounded p-4 text-primary-700 text-sm text-center">
+      {label}
+    </div>
+  )
+}
+
+export const TwoColumns: Story = {
+  args: {
+    cols: 2,
+    gap: 'md',
+    children: [1, 2, 3, 4].map((n) => <Box key={n} label={`Item ${n}`} />),
+  },
+}
+
+export const ThreeColumns: Story = {
+  args: {
+    cols: 3,
+    gap: 'md',
+    children: [1, 2, 3, 4, 5, 6].map((n) => <Box key={n} label={`Item ${n}`} />),
+  },
+}
+
+export const FourColumns: Story = {
+  args: {
+    cols: 4,
+    gap: 'sm',
+    children: [1, 2, 3, 4, 5, 6, 7, 8].map((n) => <Box key={n} label={`Item ${n}`} />),
+  },
+}

--- a/src/components/ui/layout/Grid/Grid.test.tsx
+++ b/src/components/ui/layout/Grid/Grid.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Grid } from './Grid'
+
+describe('Grid', () => {
+  it('renders children', () => {
+    render(<Grid>content</Grid>)
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+
+  it('applies grid class', () => {
+    const { container } = render(<Grid>content</Grid>)
+    expect(container.firstChild).toHaveClass('grid')
+  })
+
+  it('applies default 1 col and md gap', () => {
+    const { container } = render(<Grid>content</Grid>)
+    expect(container.firstChild).toHaveClass('grid-cols-1', 'gap-4')
+  })
+
+  it('applies 3 cols', () => {
+    const { container } = render(<Grid cols={3}>content</Grid>)
+    expect(container.firstChild).toHaveClass('grid-cols-3')
+  })
+
+  it('applies 12 cols', () => {
+    const { container } = render(<Grid cols={12}>content</Grid>)
+    expect(container.firstChild).toHaveClass('grid-cols-12')
+  })
+
+  it('applies sm gap', () => {
+    const { container } = render(<Grid gap="sm">content</Grid>)
+    expect(container.firstChild).toHaveClass('gap-2')
+  })
+
+  it('applies xl gap', () => {
+    const { container } = render(<Grid gap="xl">content</Grid>)
+    expect(container.firstChild).toHaveClass('gap-8')
+  })
+
+  it('applies no gap', () => {
+    const { container } = render(<Grid gap="none">content</Grid>)
+    expect(container.firstChild).not.toHaveClass('gap-4')
+  })
+
+  it('applies additional className', () => {
+    const { container } = render(<Grid className="extra">content</Grid>)
+    expect(container.firstChild).toHaveClass('extra')
+  })
+
+  it('forwards ref', () => {
+    const ref = vi.fn()
+    render(<Grid ref={ref}>content</Grid>)
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement))
+  })
+})

--- a/src/components/ui/layout/Grid/Grid.tsx
+++ b/src/components/ui/layout/Grid/Grid.tsx
@@ -1,0 +1,52 @@
+import { type HTMLAttributes, forwardRef } from 'react'
+import { cn } from '@/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+const gridVariants = cva('grid', {
+  variants: {
+    cols: {
+      1: 'grid-cols-1',
+      2: 'grid-cols-2',
+      3: 'grid-cols-3',
+      4: 'grid-cols-4',
+      5: 'grid-cols-5',
+      6: 'grid-cols-6',
+      12: 'grid-cols-12',
+    },
+    gap: {
+      none: '',
+      xs: 'gap-1',
+      sm: 'gap-2',
+      md: 'gap-4',
+      lg: 'gap-6',
+      xl: 'gap-8',
+    },
+  },
+  defaultVariants: {
+    cols: 1,
+    gap: 'md',
+  },
+})
+
+export interface GridProps
+  extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof gridVariants> {}
+
+/**
+ * CSS grid layout component.
+ *
+ * @example
+ * ```tsx
+ * <Grid cols={3} gap="md">
+ *   <Card />
+ *   <Card />
+ *   <Card />
+ * </Grid>
+ * ```
+ */
+export const Grid = forwardRef<HTMLDivElement, GridProps>(
+  ({ cols, gap, className, ...props }, ref) => (
+    <div ref={ref} className={cn(gridVariants({ cols, gap }), className)} {...props} />
+  )
+)
+
+Grid.displayName = 'Grid'

--- a/src/components/ui/layout/Grid/index.ts
+++ b/src/components/ui/layout/Grid/index.ts
@@ -1,0 +1,2 @@
+export { Grid } from './Grid'
+export type { GridProps } from './Grid'

--- a/src/components/ui/layout/Spacer/Spacer.stories.tsx
+++ b/src/components/ui/layout/Spacer/Spacer.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Spacer } from './Spacer'
+
+const meta: Meta<typeof Spacer> = {
+  title: 'UI/Layout/Spacer',
+  component: Spacer,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+export const Sizes: StoryObj = {
+  render: () => (
+    <div className="flex flex-col gap-2 bg-gray-50 p-4 rounded">
+      {(['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const).map((size) => (
+        <div key={size} className="flex items-center gap-2">
+          <span className="text-xs text-gray-500 w-8">{size}</span>
+          <div className="bg-blue-200 inline-block">
+            <Spacer size={size} />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+}
+
+export const FlexSpacer: StoryObj = {
+  render: () => (
+    <div className="flex bg-gray-100 p-4 rounded w-full border">
+      <div className="bg-blue-200 px-3 py-1 rounded text-sm">Logo</div>
+      <Spacer flex />
+      <div className="bg-blue-200 px-3 py-1 rounded text-sm">Nav</div>
+    </div>
+  ),
+}

--- a/src/components/ui/layout/Spacer/Spacer.test.tsx
+++ b/src/components/ui/layout/Spacer/Spacer.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Spacer } from './Spacer'
+
+describe('Spacer', () => {
+  it('renders an aria-hidden element', () => {
+    const { container } = render(<Spacer />)
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('applies default md size', () => {
+    const { container } = render(<Spacer />)
+    expect(container.firstChild).toHaveClass('h-4', 'w-4')
+  })
+
+  it('applies xs size', () => {
+    const { container } = render(<Spacer size="xs" />)
+    expect(container.firstChild).toHaveClass('h-1', 'w-1')
+  })
+
+  it('applies xl size', () => {
+    const { container } = render(<Spacer size="xl" />)
+    expect(container.firstChild).toHaveClass('h-8', 'w-8')
+  })
+
+  it('applies 2xl size', () => {
+    const { container } = render(<Spacer size="2xl" />)
+    expect(container.firstChild).toHaveClass('h-12', 'w-12')
+  })
+
+  it('applies flex-grow when flex is true', () => {
+    const { container } = render(<Spacer flex />)
+    expect(container.firstChild).toHaveClass('flex-grow')
+  })
+
+  it('does not apply size classes when flex is true', () => {
+    const { container } = render(<Spacer flex size="md" />)
+    expect(container.firstChild).not.toHaveClass('h-4')
+  })
+
+  it('applies additional className', () => {
+    const { container } = render(<Spacer className="extra" />)
+    expect(container.firstChild).toHaveClass('extra')
+  })
+})

--- a/src/components/ui/layout/Spacer/Spacer.tsx
+++ b/src/components/ui/layout/Spacer/Spacer.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils'
+
+export type SpacerSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
+
+const sizeMap: Record<SpacerSize, string> = {
+  xs: 'h-1 w-1',
+  sm: 'h-2 w-2',
+  md: 'h-4 w-4',
+  lg: 'h-6 w-6',
+  xl: 'h-8 w-8',
+  '2xl': 'h-12 w-12',
+}
+
+export interface SpacerProps {
+  /** Spacing size */
+  size?: SpacerSize
+  /** Make the spacer fill remaining space (flex-grow) */
+  flex?: boolean
+  /** Additional className */
+  className?: string
+}
+
+/**
+ * Invisible spacer element for layout spacing.
+ *
+ * @example
+ * ```tsx
+ * <Flex>
+ *   <Logo />
+ *   <Spacer flex />
+ *   <Nav />
+ * </Flex>
+ * ```
+ */
+export function Spacer({ size = 'md', flex = false, className }: SpacerProps) {
+  return <div aria-hidden="true" className={cn(flex ? 'flex-grow' : sizeMap[size], className)} />
+}

--- a/src/components/ui/layout/Spacer/index.ts
+++ b/src/components/ui/layout/Spacer/index.ts
@@ -1,0 +1,2 @@
+export { Spacer } from './Spacer'
+export type { SpacerProps, SpacerSize } from './Spacer'

--- a/src/components/ui/layout/Stack/Stack.stories.tsx
+++ b/src/components/ui/layout/Stack/Stack.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Stack } from './Stack'
+
+const meta: Meta<typeof Stack> = {
+  title: 'UI/Layout/Stack',
+  component: Stack,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+function Box({ label }: { label: string }) {
+  return (
+    <div className="bg-primary-50 border border-primary-200 rounded px-3 py-2 text-primary-700 text-sm">
+      {label}
+    </div>
+  )
+}
+
+export const Vertical: StoryObj = {
+  render: () => (
+    <Stack spacing="md">
+      <Box label="Item 1" />
+      <Box label="Item 2" />
+      <Box label="Item 3" />
+    </Stack>
+  ),
+}
+
+export const Horizontal: StoryObj = {
+  render: () => (
+    <Stack direction="horizontal" spacing="md">
+      <Box label="Item 1" />
+      <Box label="Item 2" />
+      <Box label="Item 3" />
+    </Stack>
+  ),
+}
+
+export const SmallSpacing: StoryObj = {
+  render: () => (
+    <Stack spacing="sm">
+      <Box label="Item 1" />
+      <Box label="Item 2" />
+      <Box label="Item 3" />
+    </Stack>
+  ),
+}
+
+export const CenterAligned: StoryObj = {
+  render: () => (
+    <Stack direction="horizontal" spacing="md" align="center">
+      <div className="w-10 h-10 rounded-full bg-primary-600 flex items-center justify-center text-white text-xs">
+        MU
+      </div>
+      <div>
+        <p className="font-semibold text-gray-900">Manchester United</p>
+        <p className="text-xs text-gray-500">Premier League</p>
+      </div>
+    </Stack>
+  ),
+}

--- a/src/components/ui/layout/Stack/Stack.test.tsx
+++ b/src/components/ui/layout/Stack/Stack.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Stack } from './Stack'
+
+describe('Stack', () => {
+  it('renders children', () => {
+    render(<Stack>content</Stack>)
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+
+  it('applies flex class', () => {
+    const { container } = render(<Stack>content</Stack>)
+    expect(container.firstChild).toHaveClass('flex')
+  })
+
+  it('applies vertical direction by default', () => {
+    const { container } = render(<Stack>content</Stack>)
+    expect(container.firstChild).toHaveClass('flex-col')
+  })
+
+  it('applies horizontal direction', () => {
+    const { container } = render(<Stack direction="horizontal">content</Stack>)
+    expect(container.firstChild).toHaveClass('flex-row')
+  })
+
+  it('applies default md spacing', () => {
+    const { container } = render(<Stack>content</Stack>)
+    expect(container.firstChild).toHaveClass('gap-4')
+  })
+
+  it('applies sm spacing', () => {
+    const { container } = render(<Stack spacing="sm">content</Stack>)
+    expect(container.firstChild).toHaveClass('gap-2')
+  })
+
+  it('applies xl spacing', () => {
+    const { container } = render(<Stack spacing="xl">content</Stack>)
+    expect(container.firstChild).toHaveClass('gap-8')
+  })
+
+  it('applies no spacing', () => {
+    const { container } = render(<Stack spacing="none">content</Stack>)
+    expect(container.firstChild).not.toHaveClass('gap-4')
+  })
+
+  it('applies center alignment', () => {
+    const { container } = render(<Stack align="center">content</Stack>)
+    expect(container.firstChild).toHaveClass('items-center')
+  })
+
+  it('applies additional className', () => {
+    const { container } = render(<Stack className="extra">content</Stack>)
+    expect(container.firstChild).toHaveClass('extra')
+  })
+
+  it('forwards ref', () => {
+    const ref = vi.fn()
+    render(<Stack ref={ref}>content</Stack>)
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement))
+  })
+})

--- a/src/components/ui/layout/Stack/Stack.tsx
+++ b/src/components/ui/layout/Stack/Stack.tsx
@@ -1,0 +1,58 @@
+import { type HTMLAttributes, forwardRef } from 'react'
+import { cn } from '@/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+const stackVariants = cva('flex', {
+  variants: {
+    direction: {
+      vertical: 'flex-col',
+      horizontal: 'flex-row',
+    },
+    spacing: {
+      none: '',
+      xs: 'gap-1',
+      sm: 'gap-2',
+      md: 'gap-4',
+      lg: 'gap-6',
+      xl: 'gap-8',
+    },
+    align: {
+      start: 'items-start',
+      center: 'items-center',
+      end: 'items-end',
+      stretch: 'items-stretch',
+    },
+  },
+  defaultVariants: {
+    direction: 'vertical',
+    spacing: 'md',
+    align: 'stretch',
+  },
+})
+
+export interface StackProps
+  extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof stackVariants> {}
+
+/**
+ * Stack layout component for arranging children vertically or horizontally with even spacing.
+ *
+ * @example
+ * ```tsx
+ * <Stack spacing="md">
+ *   <Card />
+ *   <Card />
+ *   <Card />
+ * </Stack>
+ * ```
+ */
+export const Stack = forwardRef<HTMLDivElement, StackProps>(
+  ({ direction, spacing, align, className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(stackVariants({ direction, spacing, align }), className)}
+      {...props}
+    />
+  )
+)
+
+Stack.displayName = 'Stack'

--- a/src/components/ui/layout/Stack/index.ts
+++ b/src/components/ui/layout/Stack/index.ts
@@ -1,0 +1,2 @@
+export { Stack } from './Stack'
+export type { StackProps } from './Stack'

--- a/src/components/ui/layout/index.ts
+++ b/src/components/ui/layout/index.ts
@@ -1,1 +1,17 @@
-export {}
+export { Container } from './Container'
+export type { ContainerProps } from './Container'
+
+export { Grid } from './Grid'
+export type { GridProps } from './Grid'
+
+export { Flex } from './Flex'
+export type { FlexProps } from './Flex'
+
+export { Divider } from './Divider'
+export type { DividerProps, DividerOrientation } from './Divider'
+
+export { Spacer } from './Spacer'
+export type { SpacerProps, SpacerSize } from './Spacer'
+
+export { Stack } from './Stack'
+export type { StackProps } from './Stack'


### PR DESCRIPTION
## Summary

- Implements **TASK-034 through TASK-039** of the Phase 1 Design System
- Adds `Container`, `Grid`, `Flex`, `Divider`, `Spacer`, `Stack`
- All components: TypeScript strict types, CVA variants, forwardRef where applicable, ARIA roles
- 57 tests passing, Storybook stories with autodocs for each component

## Components

| Component | Description |
|---|---|
| `Container` | Centered, width-constrained wrapper with maxWidth variants (sm/md/lg/xl/2xl/full) |
| `Grid` | CSS grid layout with cols (1-6,12) and gap variants |
| `Flex` | Flexbox layout with direction, align, justify, wrap, gap variants |
| `Divider` | Horizontal/vertical separator with optional centered label |
| `Spacer` | Invisible spacing element with size variants and flex-grow support |
| `Stack` | Convenience flex stack for vertical/horizontal layouts with even spacing |

## Test plan

- [x] `npm run test:run` — 57 tests pass across 6 test files
- [x] ESLint + Prettier pass (lint-staged)
- [x] TypeScript strict mode — no type errors
- [x] Storybook stories for all 6 components

🤖 Generated with [Claude Code](https://claude.com/claude-code)