### PR TITLE
test(test): Playwright E2E test suite [TASK-089-096]

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+import { mockApi } from './fixtures/api'
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page)
+})
+
+test('home page has a banner landmark', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('banner')).toBeVisible()
+})
+
+test('home page title is set', async ({ page }) => {
+  await page.goto('/')
+  await expect(page).toHaveTitle(/manchester united|mu dashboard|sports/i)
+})
+
+test('score board region is labelled', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('region', { name: 'Score board' })).toBeVisible()
+})
+
+test('standings table is labelled', async ({ page }) => {
+  await page.goto('/standings')
+  await expect(page.getByRole('table', { name: 'League standings' })).toBeVisible()
+})
+
+test('header logo link has aria-label', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('link', { name: /Manchester United Dashboard home/i })).toBeVisible()
+})
+
+test('game page stats region is labelled', async ({ page }) => {
+  await page.goto('/game/1')
+  await expect(page.getByRole('region', { name: 'Match statistics' })).toBeVisible()
+})

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -1,0 +1,107 @@
+import type { Page } from '@playwright/test'
+
+const scores = [
+  {
+    id: 1,
+    homeTeam: { id: 33, name: 'Manchester United', shortName: 'MUN', primaryColor: '#DA291C' },
+    awayTeam: { id: 49, name: 'Chelsea', shortName: 'CHE', primaryColor: '#034694' },
+    homeScore: 2,
+    awayScore: 1,
+    status: 'finished',
+    date: '2024-03-15T15:00:00Z',
+    league: { id: 39, name: 'Premier League', country: 'England', season: '2023/24' },
+  },
+  {
+    id: 3,
+    homeTeam: { id: 33, name: 'Manchester United', shortName: 'MUN', primaryColor: '#DA291C' },
+    awayTeam: { id: 50, name: 'Manchester City', shortName: 'MCI', primaryColor: '#6CABDD' },
+    homeScore: 1,
+    awayScore: 1,
+    status: 'live',
+    minute: 67,
+    date: '2024-03-18T19:45:00Z',
+    league: { id: 39, name: 'Premier League', country: 'England', season: '2023/24' },
+  },
+]
+
+const standings = [
+  {
+    position: 1,
+    team: { id: 50, name: 'Manchester City', shortName: 'MCI', primaryColor: '#6CABDD' },
+    played: 28,
+    won: 20,
+    drawn: 4,
+    lost: 4,
+    goalsFor: 62,
+    goalsAgainst: 28,
+    goalDifference: 34,
+    points: 64,
+    form: ['W', 'W', 'D', 'W', 'W'],
+  },
+  {
+    position: 6,
+    team: { id: 33, name: 'Manchester United', shortName: 'MUN', primaryColor: '#DA291C' },
+    played: 28,
+    won: 12,
+    drawn: 4,
+    lost: 12,
+    goalsFor: 29,
+    goalsAgainst: 43,
+    goalDifference: -14,
+    points: 40,
+    form: ['L', 'W', 'D', 'L', 'W'],
+  },
+]
+
+const stats = {
+  matchId: 1,
+  home: {
+    possession: 55,
+    shots: 14,
+    shotsOnTarget: 6,
+    corners: 7,
+    fouls: 11,
+    yellowCards: 1,
+    redCards: 0,
+    offsides: 2,
+    passes: 512,
+    passAccuracy: 87,
+  },
+  away: {
+    possession: 45,
+    shots: 9,
+    shotsOnTarget: 3,
+    corners: 4,
+    fouls: 14,
+    yellowCards: 2,
+    redCards: 0,
+    offsides: 3,
+    passes: 418,
+    passAccuracy: 82,
+  },
+}
+
+const leagues = [
+  { id: 39, name: 'Premier League', country: 'England', season: '2023/24', teamCount: 20 },
+]
+
+/** Register API mocks for all sports endpoints */
+export async function mockApi(page: Page) {
+  await page.route('**/api/sports/scores**', (route) =>
+    route.fulfill({ json: { data: scores, status: 200 } })
+  )
+  await page.route('**/api/sports/standings**', (route) =>
+    route.fulfill({ json: { data: standings, status: 200 } })
+  )
+  // wildcard registered first so it's lower priority (Playwright LIFO)
+  await page.route('**/api/sports/stats/**', (route) =>
+    route.fulfill({ status: 404, json: { status: 404, message: 'Match not found' } })
+  )
+  await page.route('**/api/sports/stats/1', (route) =>
+    route.fulfill({ json: { data: stats, status: 200 } })
+  )
+  await page.route('**/api/sports/leagues**', (route) =>
+    route.fulfill({ json: { data: leagues, total: 1, page: 1, pageSize: 10, totalPages: 1 } })
+  )
+  await page.route('**/api/health**', (route) => route.fulfill({ json: { status: 'ok' } }))
+}

--- a/e2e/game.spec.ts
+++ b/e2e/game.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+import { mockApi } from './fixtures/api'
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page)
+})
+
+test('game page shows match statistics', async ({ page }) => {
+  await page.goto('/game/1')
+  await expect(page.getByRole('region', { name: 'Match statistics' })).toBeVisible()
+  await expect(page.getByText('Possession')).toBeVisible()
+  await expect(page.getByText('Shots', { exact: true })).toBeVisible()
+})
+
+test('game page shows back button', async ({ page }) => {
+  await page.goto('/game/1')
+  await expect(page.getByLabel('Go back')).toBeVisible()
+})
+
+test('game page shows error for unknown match', async ({ page }) => {
+  await page.goto('/game/9999')
+  await expect(page.getByText('Stats not available')).toBeVisible()
+})
+
+test('back button navigates away', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByLabel('Score board')).toBeVisible()
+  await page.goto('/game/1')
+  await page.getByLabel('Go back').click()
+  // Should navigate back (to home or previous page)
+  await expect(page).not.toHaveURL('/game/1')
+})

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test'
+import { mockApi } from './fixtures/api'
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page)
+})
+
+test('home page shows the header', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('banner')).toBeVisible()
+  await expect(page.getByText('MU Dashboard')).toBeVisible()
+})
+
+test('home page shows score cards after load', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByLabel('Score board')).toBeVisible()
+  await expect(page.getByText('Premier League').first()).toBeVisible()
+})
+
+test('home page shows live match badge', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByText('LIVE').first()).toBeVisible()
+})
+
+test('clicking a score card navigates to game page', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByLabel('Score board')).toBeVisible()
+  // Click the first interactive score card
+  const cards = page.locator('[role="button"]')
+  await cards.first().click()
+  await expect(page).toHaveURL(/\/game\/\d+/)
+  await expect(page.getByText('Match Statistics')).toBeVisible()
+})

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import { mockApi } from './fixtures/api'
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page)
+})
+
+test('sidebar is visible on desktop', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await page.goto('/')
+  await expect(page.getByRole('navigation', { name: 'Main navigation' })).toBeVisible()
+})
+
+test('sidebar nav links are present', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await page.goto('/')
+  const nav = page.getByRole('navigation', { name: 'Main navigation' })
+  await expect(nav.getByRole('link', { name: /Home/i })).toBeVisible()
+  await expect(nav.getByRole('link', { name: /Standings/i })).toBeVisible()
+  await expect(nav.getByRole('link', { name: /Scores/i })).toBeVisible()
+})
+
+test('navigating to /standings shows standings page', async ({ page }) => {
+  await page.goto('/standings')
+  await expect(page.getByText('League Standings')).toBeVisible()
+})
+
+test('404 page shows for unknown route', async ({ page }) => {
+  await page.goto('/this-does-not-exist')
+  await expect(page.getByText('Page not found')).toBeVisible()
+  await expect(page.getByRole('heading', { name: /page not found/i })).toBeVisible()
+})
+
+test('404 page go home button navigates to /', async ({ page }) => {
+  await page.goto('/unknown-route')
+  await page.getByRole('button', { name: 'Go home' }).click()
+  await expect(page).toHaveURL('/')
+})
+
+test('search page shows search input', async ({ page }) => {
+  await page.goto('/search')
+  await expect(page.getByRole('searchbox', { name: /Search matches/i })).toBeVisible()
+})

--- a/e2e/standings.spec.ts
+++ b/e2e/standings.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { mockApi } from './fixtures/api'
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page)
+})
+
+test('standings page renders league table', async ({ page }) => {
+  await page.goto('/standings')
+  await expect(page.getByRole('table', { name: 'League standings' })).toBeVisible()
+  await expect(page.getByText('Manchester United')).toBeVisible()
+  await expect(page.getByText('Manchester City')).toBeVisible()
+})
+
+test('standings page highlights Manchester United row', async ({ page }) => {
+  await page.goto('/standings')
+  const row = page.getByRole('row').filter({ hasText: 'Manchester United' })
+  await expect(row).toBeVisible()
+  await expect(row).toHaveAttribute('aria-current', 'true')
+})
+
+test('standings table shows column headers', async ({ page }) => {
+  await page.goto('/standings')
+  await expect(page.getByRole('columnheader', { name: 'Pts' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'W' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'GD' })).toBeVisible()
+})

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Manchester United Dashboard</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@commitlint/cli": "^18.6.1",
         "@commitlint/config-conventional": "^18.6.3",
         "@eslint/js": "^9.13.0",
+        "@playwright/test": "^1.58.2",
         "@storybook/addon-a11y": "^8.6.18",
         "@storybook/addon-essentials": "^8.6.14",
         "@storybook/addon-interactions": "^8.6.14",
@@ -1949,6 +1950,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -8998,6 +9015,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/polished": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@commitlint/cli": "^18.6.1",
     "@commitlint/config-conventional": "^18.6.3",
     "@eslint/js": "^9.13.0",
+    "@playwright/test": "^1.58.2",
     "@storybook/addon-a11y": "^8.6.18",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+})


### PR DESCRIPTION
## Summary

- **playwright.config.ts** — Chromium project, dev server auto-start on `localhost:5173`
- **e2e/fixtures/api.ts** — `mockApi()` helper using `page.route()` to intercept all `/api/sports/*` endpoints
- **23 E2E tests** across 5 spec files:
  - `home.spec` — header, score board, live badge, click-to-game navigation
  - `standings.spec` — table render, Man United highlight, column headers
  - `game.spec` — stats panel, back button, unknown match error state
  - `navigation.spec` — sidebar, all routes, 404 page, search input
  - `accessibility.spec` — landmarks, page title, ARIA-labelled regions
- `index.html` title updated to "Manchester United Dashboard"

## Test plan

- [ ] `npm run test:e2e` — all 23 tests pass (Chromium)
- [ ] `npm test` — 415 unit tests still pass
- [ ] Page title shows "Manchester United Dashboard"

🤖 Generated with [Claude Code](https://claude.com/claude-code)