### PR TITLE
docs(docs): add full project documentation [TASK-097-103]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,102 @@
-# Sports Dashboard
+# Manchester United Dashboard
+
+A real-time sports dashboard for Manchester United — live scores, league standings, and match statistics. Built with React 18, TypeScript 5, TanStack Query, and Tailwind CSS.
+
+## Features
+
+- Live match scores with auto-refresh (30s stale time)
+- Premier League standings table with Manchester United highlighted
+- Per-match statistics panel (possession, shots, passes, etc.)
+- Persisted filters (league, season, status) via Zustand
+- Fully accessible (ARIA landmarks, labelled regions)
+- Responsive layout with mobile sidebar
+
+## Stack
+
+| Layer         | Technology                                |
+| ------------- | ----------------------------------------- |
+| UI            | React 18, TypeScript 5, Tailwind CSS 3    |
+| Data fetching | TanStack Query 5, Axios                   |
+| State         | Zustand 4                                 |
+| Routing       | React Router DOM 6                        |
+| Build         | Vite 5                                    |
+| Unit tests    | Vitest 1, React Testing Library 14, MSW 2 |
+| E2E tests     | Playwright                                |
+| Components    | Storybook 8                               |
+
+## Getting started
+
+```bash
+# Install dependencies
+npm install
+
+# Copy env vars
+cp .env.example .env.local
+
+# Start dev server
+npm run dev
+```
+
+Open `http://localhost:5173`.
+
+## Environment variables
+
+| Variable            | Default | Description                        |
+| ------------------- | ------- | ---------------------------------- |
+| `VITE_API_BASE_URL` | `/api`  | Sports API base URL                |
+| `VITE_API_KEY`      | —       | API key sent as `X-API-Key` header |
+| `VITE_API_TIMEOUT`  | `15000` | Request timeout in ms              |
+
+## Scripts
+
+```bash
+npm run dev          # Dev server
+npm run build        # Production build
+npm run preview      # Preview production build
+npm run lint         # ESLint
+npm run test         # Vitest watch mode
+npm run test:run     # Vitest single run
+npm run test:coverage # Coverage report
+npm run test:e2e     # Playwright E2E tests
+npm run storybook    # Storybook dev server
+```
+
+## Project structure
+
+```
+src/
+  components/
+    ui/          # Design system: buttons, cards, feedback, inputs, layout
+    features/    # Feature components: ScoreBoard, StandingsTable, GameStatsPanel
+    layout/      # App shell: Header, Sidebar
+  hooks/
+    sports/      # useScores, useStandings, useMatchStats, useLeagues
+    use*/        # Utility hooks: useDebounce, useLocalStorage, etc.
+  pages/         # Home, Standings, Game, Search, League, NotFound
+  router/        # AppRouter (BrowserRouter + Routes)
+  services/
+    api/         # Axios client, interceptors, types
+    sports/      # Service functions, domain types
+  stores/        # Zustand: useFiltersStore, useUIStore
+  lib/           # queryClient, format utilities, utils
+  tests/
+    mocks/       # MSW server, handlers, fixture data
+e2e/             # Playwright specs + API fixtures
+```
+
+## Testing
+
+```bash
+# Unit + integration (Vitest + MSW)
+npm run test:run
+
+# E2E (Playwright — requires dev server)
+npm run test:e2e
+```
+
+The test suite includes 415 unit tests and 23 E2E tests.
+
+## Contributing
+
+Commits must follow [Conventional Commits](https://www.conventionalcommits.org/).
+All components require a Storybook story and >80% test coverage.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,133 @@
+# API Reference
+
+## Configuration
+
+| Env var             | Description                                 |
+| ------------------- | ------------------------------------------- |
+| `VITE_API_BASE_URL` | Base URL for all requests (default: `/api`) |
+| `VITE_API_KEY`      | Sent as `X-API-Key` header when set         |
+| `VITE_API_TIMEOUT`  | Request timeout ms (default: `15000`)       |
+
+## Endpoints
+
+### GET `/sports/scores`
+
+Returns a list of matches.
+
+Query params:
+
+- `leagueId` — filter by league
+- `date` — filter by date (ISO 8601)
+- `status` — `scheduled | live | finished | postponed | cancelled`
+
+Response: `ApiResponse<Match[]>`
+
+### GET `/sports/standings`
+
+Returns the league table for a given league and season.
+
+Query params:
+
+- `leagueId` _(required)_
+- `season` _(required)_ — e.g. `2023/24`
+
+Response: `ApiResponse<Standing[]>`
+
+### GET `/sports/stats/:matchId`
+
+Returns statistics for a single match.
+
+Response: `ApiResponse<GameStats>` or `404` if not found.
+
+### GET `/sports/leagues`
+
+Returns all available leagues.
+
+Response: `PaginatedResponse<League>`
+
+## Types
+
+```ts
+interface Match {
+  id: number
+  homeTeam: Team
+  awayTeam: Team
+  homeScore?: number
+  awayScore?: number
+  status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
+  minute?: number
+  date: string // ISO 8601
+  league: League
+}
+
+interface Team {
+  id: number
+  name: string
+  shortName: string
+  logo?: string
+  primaryColor?: string
+}
+
+interface League {
+  id: number
+  name: string
+  country: string
+  season: string
+  logo?: string
+  teamCount?: number
+}
+
+interface Standing {
+  position: number
+  team: Team
+  played: number
+  won: number
+  drawn: number
+  lost: number
+  goalsFor: number
+  goalsAgainst: number
+  goalDifference: number
+  points: number
+  form?: string[] // ['W', 'D', 'L', ...]
+}
+
+interface GameStats {
+  matchId: number
+  home: TeamGameStats
+  away: TeamGameStats
+}
+
+interface TeamGameStats {
+  possession: number
+  shots: number
+  shotsOnTarget: number
+  corners: number
+  fouls: number
+  yellowCards: number
+  redCards: number
+  offsides: number
+  passes: number
+  passAccuracy: number
+}
+```
+
+## Error shape
+
+All errors from the response interceptor are normalized to:
+
+```ts
+interface ApiError {
+  status: number // HTTP status code, 0 for network errors
+  message: string // Human-readable message
+  code?: string // Optional error code from API
+}
+```
+
+## React Query hooks
+
+| Hook                     | Query key                         | Enabled when             |
+| ------------------------ | --------------------------------- | ------------------------ |
+| `useScores(params?)`     | `['scores', params]`              | always                   |
+| `useStandings(params)`   | `['standings', leagueId, season]` | `leagueId > 0 && season` |
+| `useMatchStats(matchId)` | `['stats', matchId]`              | `matchId > 0`            |
+| `useLeagues()`           | `['leagues']`                     | always                   |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,80 @@
+# Architecture
+
+## Overview
+
+The dashboard is a single-page application (SPA) built with React and served by Vite. All data is fetched from a REST API (configurable via `VITE_API_BASE_URL`). The application has no backend of its own.
+
+```
+Browser
+  └─ React SPA (Vite)
+       ├─ React Router   → page routing
+       ├─ TanStack Query → server state (cache, refetch)
+       ├─ Zustand        → client state (filters, UI)
+       └─ Axios          → HTTP transport
+            └─ REST API (external)
+```
+
+## Data flow
+
+```
+User action
+  → Zustand store update (filters/UI)
+    → React Query hook re-fires query
+      → Axios request + interceptors
+        → API response
+          → Query cache update
+            → Component re-render
+```
+
+## Layers
+
+### Services (`src/services/`)
+
+- **`api/`** — Axios instance with request interceptor (X-API-Key) and response interceptor (error normalization to `ApiError`).
+- **`sports/`** — Domain functions: `getScores`, `getStandings`, `getMatchStats`, `getLeagues`. Return typed domain objects.
+
+### Hooks (`src/hooks/`)
+
+- **`sports/`** — React Query wrappers: `useScores`, `useStandings`, `useMatchStats`, `useLeagues`. Each exposes `{ data, isLoading, isError }`.
+- **Utility hooks** — `useDebounce`, `useLocalStorage`, `useMediaQuery`, `usePagination`, etc.
+
+### Stores (`src/stores/`)
+
+- **`useFiltersStore`** — persisted (localStorage) league/season/status/date filters.
+- **`useUIStore`** — ephemeral sidebar open state and theme.
+
+### Components (`src/components/`)
+
+Three tiers:
+
+| Tier          | Path        | Purpose                                           |
+| ------------- | ----------- | ------------------------------------------------- |
+| Design system | `ui/`       | Primitive, reusable, data-agnostic components     |
+| Feature       | `features/` | Data-aware components composed from UI primitives |
+| Layout        | `layout/`   | App shell (Header, Sidebar)                       |
+
+### Pages (`src/pages/`)
+
+Thin wrappers that compose feature components and read from stores.
+
+### Router (`src/router/`)
+
+`AppRouter` wraps the entire tree with `BrowserRouter`. Routes are defined as plain `<Route>` elements — no code-splitting for now.
+
+## QueryClient defaults
+
+| Setting                | Value | Rationale                            |
+| ---------------------- | ----- | ------------------------------------ |
+| `staleTime`            | 30 s  | Scores change frequently             |
+| `gcTime`               | 5 min | Keep cache alive across tab switches |
+| `retry`                | 1     | Fail fast for live data              |
+| `refetchOnWindowFocus` | true  | Re-sync when tab regains focus       |
+| mutation `retry`       | 0     | Never silently retry writes          |
+
+## MSW (Mock Service Worker)
+
+Used in unit/integration tests only (`src/tests/mocks/`). The handlers mirror the real API contract. E2E tests use Playwright `page.route()` interception instead.
+
+## Environment-based configuration
+
+All runtime config is injected via Vite's `import.meta.env`. No secrets are bundled — the API key is read at runtime from `VITE_API_KEY`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Changelog
+
+All notable changes are documented here. Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.6.0] — Phase 6: Documentation
+
+### Added
+
+- `README.md` rewritten with project overview, stack, scripts, and structure
+- `docs/ARCHITECTURE.md` — data flow, layers, QueryClient defaults
+- `docs/COMPONENTS.md` — full component catalogue
+- `docs/API.md` — endpoint reference, types, React Query hooks
+- `docs/TESTING.md` — testing strategy, conventions, coverage targets
+- `docs/STANDARDS.md` — commit, branching, code, accessibility standards
+- `docs/CHANGELOG.md` — this file
+
+## [0.5.0] — Phase 5: E2E Tests
+
+### Added
+
+- Playwright configuration (Chromium, dev server auto-start)
+- 23 E2E tests across 5 spec files: home, standings, game, navigation, accessibility
+- API fixture helper (`e2e/fixtures/api.ts`) using `page.route()`
+- `index.html` title updated to "Manchester United Dashboard"
+
+## [0.4.0] — Phase 4: Feature Components
+
+### Added
+
+- `ScoreBoard` and `LiveScore` feature components
+- `StandingsTable` with form badges and team highlighting
+- `GameStatsPanel` with dual-bar stat rows
+- `Header` and `Sidebar` layout components
+- `AppRouter` with React Router DOM 6
+- Pages: Home, Standings, Game, Search, League, NotFound
+- `useFiltersStore` (persisted) and `useUIStore` Zustand stores
+- `App.tsx` wired with `QueryClientProvider` + `AppRouter`
+- Installed: `react-router-dom`
+
+## [0.3.0] — Phase 3: Services Layer
+
+### Added
+
+- Axios client with configurable base URL and timeout
+- Request interceptor: `X-API-Key` header injection
+- Response interceptor: error normalization to `ApiError`
+- Sports domain types: `Match`, `Team`, `Standing`, `GameStats`, `League`
+- Service functions: `getScores`, `getStandings`, `getMatchStats`, `getLeagues`
+- React Query hooks: `useScores`, `useStandings`, `useMatchStats`, `useLeagues`
+- `QueryClient` with `staleTime: 30s`, `gcTime: 5min`, `retry: 1`
+- MSW handlers for all sports endpoints
+- Mock fixture data for scores, standings, stats, leagues
+- Installed: `axios`, `@tanstack/react-query`, `zustand`
+
+## [0.2.0] — Phase 2: Utility Hooks
+
+### Added
+
+- `useDebounce`, `useDebouncedCallback`
+- `useLocalStorage`
+- `useMediaQuery`
+- `useOutsideClick`
+- `useToggle`
+- `usePagination`
+- `useInfiniteScroll`
+- `useCopyToClipboard`
+- `useCountdown`
+- Utility functions: `formatDate`, `formatScore`, `formatStanding`, `formatDuration`, `formatNumber`
+
+## [0.1.0] — Phase 1: Design System
+
+### Added
+
+- Button, IconButton, ButtonGroup
+- Card, CardHeader, CardBody, CardFooter
+- ScoreCard, StatsCard, TeamCard, LeagueCard
+- Spinner, Skeleton, Badge, Chip, Toast, ErrorBoundary, EmptyState
+- TextInput, SearchInput, SelectInput, Toggle, DatePicker
+- Container, Grid, Flex, Stack, Divider, Spacer
+
+## [0.0.1] — Phase 0: Project Setup
+
+### Added
+
+- Vite 5 + React 18 + TypeScript 5 project
+- Tailwind CSS 3 + PostCSS
+- ESLint 9 + Prettier
+- Husky 9 + lint-staged + commitlint
+- Vitest 1 + React Testing Library 14 + happy-dom
+- Storybook 8 + autodocs
+- MSW 2 server setup
+- GitHub Actions CI (Lint, TypeScript, Tests, Build)
+- PR template, issue templates, labels
+- `.env.example`
+- Path aliases (`@/` → `src/`)

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1,0 +1,81 @@
+# Components
+
+All components follow these conventions:
+
+- TypeScript strict mode, `forwardRef` where refs are needed
+- CVA (class-variance-authority) for variant styles
+- ARIA roles and labels for accessibility
+- Storybook story (autodocs)
+- Vitest + React Testing Library tests
+
+## Design system (`src/components/ui/`)
+
+### Buttons
+
+| Component     | Description                                                                                                      |
+| ------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `Button`      | Primary action button. Variants: `default`, `primary`, `secondary`, `danger`, `ghost`, `link`. Sizes: `xs`–`xl`. |
+| `IconButton`  | Square button with icon, accessible `aria-label`.                                                                |
+| `ButtonGroup` | Horizontal group of related buttons.                                                                             |
+
+### Cards
+
+| Component    | Description                                                                                                       |
+| ------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `Card`       | Base card shell. Variants: `default`, `interactive`, `outlined`, `elevated`.                                      |
+| `CardHeader` | Card title + optional subtitle.                                                                                   |
+| `CardBody`   | Card content area with padding.                                                                                   |
+| `CardFooter` | Card action area.                                                                                                 |
+| `ScoreCard`  | Match score with team names, status badge (`live`/`finished`/`upcoming`/`postponed`), and optional click handler. |
+| `StatsCard`  | Metric with trend indicator (up/down/neutral), icon, and optional description.                                    |
+| `TeamCard`   | Team info with position, points, record, and logo.                                                                |
+| `LeagueCard` | League info with country, season, team count.                                                                     |
+
+### Feedback
+
+| Component       | Description                                                                          |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `Spinner`       | Loading indicator. Sizes: `xs`–`xl`. Colors: `default`, `primary`, `white`.          |
+| `Skeleton`      | Animated placeholder. Variants: `text`, `heading`, `circle`, `rectangle`, `card`.    |
+| `Badge`         | Status chip. Variants: `default`, `primary`, `success`, `warning`, `danger`, `info`. |
+| `Chip`          | Filter tag with optional remove button and selected state.                           |
+| `Toast`         | Contextual notification via `useToast()` hook. Auto-dismiss. `role="alert"`.         |
+| `ErrorBoundary` | Class component catching render errors. Accepts ReactNode or function fallback.      |
+| `EmptyState`    | Zero-state placeholder with title, description, optional icon and action.            |
+
+### Inputs
+
+| Component     | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `TextInput`   | Text field with label, helper text, error state. |
+| `SearchInput` | Text field with search icon and clear button.    |
+| `SelectInput` | Native `<select>` with label and error state.    |
+| `Toggle`      | Accessible on/off switch.                        |
+| `DatePicker`  | Native date input with label.                    |
+
+### Layout
+
+| Component   | Description                                                   |
+| ----------- | ------------------------------------------------------------- |
+| `Container` | Max-width wrapper. Sizes: `sm`–`2xl`, `full`.                 |
+| `Grid`      | CSS grid with configurable columns (1–12) and gaps.           |
+| `Flex`      | Flexbox wrapper with direction, align, justify, gap variants. |
+| `Stack`     | Vertical or horizontal stack with configurable spacing.       |
+| `Divider`   | Horizontal rule, vertical rule, or labeled divider.           |
+| `Spacer`    | Flexible space filler.                                        |
+
+## Feature components (`src/components/features/`)
+
+| Component        | Hook             | Description                                                             |
+| ---------------- | ---------------- | ----------------------------------------------------------------------- |
+| `ScoreBoard`     | `useScores`      | Responsive grid of `ScoreCard` items. Shows spinner/empty/error states. |
+| `LiveScore`      | via `ScoreBoard` | `ScoreBoard` pre-filtered to `status='live'`.                           |
+| `StandingsTable` | `useStandings`   | League table with form badges. Highlights a specified team.             |
+| `GameStatsPanel` | `useMatchStats`  | Dual-bar possession/shots/passes display.                               |
+
+## Layout components (`src/components/layout/`)
+
+| Component | Description                                                                 |
+| --------- | --------------------------------------------------------------------------- |
+| `Header`  | Fixed top bar with MU branding and hamburger toggle (mobile).               |
+| `Sidebar` | Navigation links. Slides in from left on mobile; always visible on desktop. |

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -1,0 +1,61 @@
+# Development Standards
+
+## Commits
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/). Enforced by commitlint + Husky.
+
+```
+<type>(<scope>): <description>
+```
+
+Allowed types: `feat`, `fix`, `chore`, `test`, `docs`, `refactor`, `perf`, `ci`
+
+Allowed scopes: `ui`, `hooks`, `api`, `config`, `deps`, `types`, `test`, `docs`, `router`, `store`, `scores`, `standings`, `stats`, `leagues`, `layout`
+
+Header max length: 100 characters. Body lines max length: 100 characters.
+
+## Branching
+
+```
+main          ← production, merges from develop at phase end
+develop       ← integration, merges from feature branches
+feature/*     ← one branch per task (feature/TASK-NNN-slug)
+```
+
+## Code style
+
+- TypeScript strict mode (`strict: true` in tsconfig)
+- ESLint + Prettier enforced via lint-staged on pre-commit
+- No `any` types without a comment explaining why
+- Prefer `type` over `interface` for unions; use `interface` for object shapes that may be extended
+
+## Component conventions
+
+- Use `forwardRef` for all leaf UI components
+- Use CVA for variant styles
+- All interactive elements must have an accessible label
+- Export both the component and its props type from the barrel `index.ts`
+
+## File layout (example)
+
+```
+src/components/ui/buttons/Button/
+  Button.tsx         ← component
+  Button.test.tsx    ← unit tests
+  Button.stories.tsx ← Storybook
+  index.ts           ← barrel export
+```
+
+## Pull requests
+
+- One PR per task
+- PR must pass all CI checks (Lint, TypeScript, Tests, Build)
+- PR base branch is `develop`
+- Use the PR template
+
+## Accessibility
+
+- All images must have `alt` text
+- All form inputs must have associated labels
+- Interactive elements that are not `<button>` or `<a>` must have `role` + `tabIndex`
+- Use semantic HTML (`<main>`, `<nav>`, `<header>`, `<section>` with `aria-label`)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,79 @@
+# Testing
+
+## Stack
+
+| Layer              | Tool                                |
+| ------------------ | ----------------------------------- |
+| Unit / integration | Vitest 1 + React Testing Library 14 |
+| API mocking        | MSW 2 (Node adapter in tests)       |
+| DOM                | happy-dom                           |
+| Coverage           | `@vitest/coverage-v8`               |
+| E2E                | Playwright (Chromium)               |
+
+## Running tests
+
+```bash
+# Unit tests (watch mode)
+npm test
+
+# Unit tests (single run)
+npm run test:run
+
+# Coverage report
+npm run test:coverage
+
+# E2E tests (requires dev server on :5173)
+npm run test:e2e
+
+# E2E with UI
+npm run test:e2e:ui
+```
+
+## Unit test conventions
+
+- Test files live next to the source file: `Foo.test.tsx`
+- Use `describe` + `it` (not `test`) for grouping
+- Prefer `screen.getByRole` over `getByTestId`
+- Never mock internal modules — only mock at the network boundary (MSW)
+
+### MSW setup
+
+The test server (`src/tests/mocks/server.ts`) is started globally in `src/tests/setup.ts`:
+
+```ts
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+```
+
+Add per-test overrides with `server.use(http.get(...))`.
+
+### React Query in tests
+
+Each test that renders a hook or component using React Query must provide a fresh `QueryClient` with `retry: false`:
+
+```ts
+function createWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+```
+
+### Zustand in tests
+
+Call `useStore.setState(...)` in `beforeEach` to reset state between tests — no need to mock the module.
+
+## E2E test conventions
+
+- Specs live in `e2e/`
+- Use `page.route()` to intercept API calls (`e2e/fixtures/api.ts`)
+- Register wildcard routes BEFORE specific routes (Playwright LIFO)
+- Prefer `getByRole` + `getByLabel` over CSS selectors
+
+## Coverage targets
+
+- Overall: >80% line coverage
+- All public component props and variants covered
+- All service functions covered (success + error paths)


### PR DESCRIPTION
## Summary

- **README.md** — full rewrite: features, stack, setup, scripts, folder structure
- **docs/ARCHITECTURE.md** — data flow, layer diagram, QueryClient config table
- **docs/COMPONENTS.md** — complete catalogue of all 30+ components
- **docs/API.md** — endpoint reference, request/response types, hook query keys
- **docs/TESTING.md** — unit/E2E conventions, MSW setup, Zustand reset pattern
- **docs/STANDARDS.md** — commits, branching, code style, accessibility rules
- **docs/CHANGELOG.md** — all 6 phases documented (v0.0.1 → v0.6.0)

## Test plan

- [ ] `npm run test:run` — 415 tests pass
- [ ] `npm run build` — clean build
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)