### PR TITLE
feat(ui): MU brand design tokens system [REDESIGN-004]

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,19 @@
 @tailwind utilities;
 
 :root {
+  /* MU Brand Design Tokens */
+  --mu-red-primary: #da291c;
+  --mu-red-secondary: #c1232b;
+  --mu-gold: #ffb81c;
+  --bg-dark: #1a1a1a;
+  --bg-card: #2a2a2a;
+  --bg-sidebar: #0e1117;
+  --text-primary: #ffffff;
+  --text-secondary: #b0b0b0;
+  --success-green: #10b981;
+  --warning-orange: #f59e0b;
+  --error-red: #ef4444;
+
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;

--- a/src/styles/tokens/__tests__/tokens.test.ts
+++ b/src/styles/tokens/__tests__/tokens.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { colors } from '../colors'
+import { typography } from '../typography'
+import { spacing } from '../spacing'
+
+const HEX_COLOR_REGEX = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/
+
+describe('Color tokens', () => {
+  const expectedColorKeys: (keyof typeof colors)[] = [
+    'mu-red-primary',
+    'mu-red-secondary',
+    'mu-gold',
+    'bg-dark',
+    'bg-card',
+    'bg-sidebar',
+    'text-primary',
+    'text-secondary',
+    'success-green',
+    'warning-orange',
+    'error-red',
+  ]
+
+  it('exports all expected color token keys', () => {
+    expectedColorKeys.forEach((key) => {
+      expect(colors).toHaveProperty(key)
+    })
+  })
+
+  it('all color tokens are valid hex strings', () => {
+    Object.entries(colors).forEach(([key, value]) => {
+      expect(value, `Token "${key}" should be a valid hex color`).toMatch(HEX_COLOR_REGEX)
+    })
+  })
+
+  it('has correct values for key MU brand colors', () => {
+    expect(colors['mu-red-primary']).toBe('#DA291C')
+    expect(colors['mu-gold']).toBe('#FFB81C')
+    expect(colors['bg-sidebar']).toBe('#0E1117')
+  })
+
+  it('has exactly 11 color tokens', () => {
+    expect(Object.keys(colors)).toHaveLength(11)
+  })
+})
+
+describe('Typography tokens', () => {
+  it('exports fontFamily with sans', () => {
+    expect(typography.fontFamily).toHaveProperty('sans')
+    expect(typography.fontFamily.sans).toContain('Inter')
+  })
+
+  it('exports fontSize with expected sizes', () => {
+    const expectedSizes = ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl']
+    expectedSizes.forEach((size) => {
+      expect(typography.fontSize).toHaveProperty(size)
+    })
+  })
+
+  it('all fontSize values are rem strings', () => {
+    Object.entries(typography.fontSize).forEach(([key, value]) => {
+      expect(value, `fontSize "${key}" should be a rem string`).toMatch(/rem$/)
+    })
+  })
+
+  it('exports fontWeight with expected weights', () => {
+    const expectedWeights = ['normal', 'medium', 'semibold', 'bold']
+    expectedWeights.forEach((weight) => {
+      expect(typography.fontWeight).toHaveProperty(weight)
+    })
+  })
+
+  it('fontWeight values are numeric strings', () => {
+    Object.entries(typography.fontWeight).forEach(([key, value]) => {
+      expect(Number(value), `fontWeight "${key}" should be numeric`).not.toBeNaN()
+    })
+  })
+})
+
+describe('Spacing tokens', () => {
+  it('exports spacing with key 0', () => {
+    expect(spacing[0]).toBe('0')
+  })
+
+  it('exports expected spacing keys', () => {
+    const expectedKeys = [0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20] as const
+    expectedKeys.forEach((key) => {
+      expect(spacing).toHaveProperty(String(key))
+    })
+  })
+
+  it('non-zero spacing values are rem strings', () => {
+    Object.entries(spacing).forEach(([key, value]) => {
+      if (key !== '0') {
+        expect(value, `spacing "${key}" should be a rem string`).toMatch(/rem$/)
+      }
+    })
+  })
+
+  it('has correct value for spacing 4 (base unit)', () => {
+    expect(spacing[4]).toBe('1rem')
+  })
+})

--- a/src/styles/tokens/colors.ts
+++ b/src/styles/tokens/colors.ts
@@ -1,0 +1,15 @@
+export const colors = {
+  'mu-red-primary': '#DA291C',
+  'mu-red-secondary': '#C1232B',
+  'mu-gold': '#FFB81C',
+  'bg-dark': '#1A1A1A',
+  'bg-card': '#2A2A2A',
+  'bg-sidebar': '#0E1117',
+  'text-primary': '#FFFFFF',
+  'text-secondary': '#B0B0B0',
+  'success-green': '#10B981',
+  'warning-orange': '#F59E0B',
+  'error-red': '#EF4444',
+} as const
+
+export type ColorToken = keyof typeof colors

--- a/src/styles/tokens/index.ts
+++ b/src/styles/tokens/index.ts
@@ -1,0 +1,4 @@
+export { colors } from './colors'
+export type { ColorToken } from './colors'
+export { typography } from './typography'
+export { spacing } from './spacing'

--- a/src/styles/tokens/spacing.ts
+++ b/src/styles/tokens/spacing.ts
@@ -1,0 +1,14 @@
+export const spacing = {
+  0: '0',
+  1: '0.25rem', // 4px
+  2: '0.5rem', // 8px
+  3: '0.75rem', // 12px
+  4: '1rem', // 16px
+  5: '1.25rem', // 20px
+  6: '1.5rem', // 24px
+  8: '2rem', // 32px
+  10: '2.5rem', // 40px
+  12: '3rem', // 48px
+  16: '4rem', // 64px
+  20: '5rem', // 80px
+} as const

--- a/src/styles/tokens/typography.ts
+++ b/src/styles/tokens/typography.ts
@@ -1,0 +1,21 @@
+export const typography = {
+  fontFamily: {
+    sans: ['Inter', 'system-ui', 'sans-serif'],
+  },
+  fontSize: {
+    xs: '0.75rem', // 12px
+    sm: '0.875rem', // 14px
+    base: '1rem', // 16px
+    lg: '1.125rem', // 18px
+    xl: '1.25rem', // 20px
+    '2xl': '1.5rem', // 24px
+    '3xl': '1.875rem', // 30px
+    '4xl': '2.25rem', // 36px
+  },
+  fontWeight: {
+    normal: '400',
+    medium: '500',
+    semibold: '600',
+    bold: '700',
+  },
+} as const

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,8 @@
 import type { Config } from 'tailwindcss'
+import { colors } from './src/styles/tokens/colors'
 
 const config: Config = {
-  content: [
-    './index.html',
-    './src/**/*.{js,ts,jsx,tsx}',
-  ],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       colors: {
@@ -21,6 +19,7 @@ const config: Config = {
           900: '#1e3a8a',
           950: '#172554',
         },
+        ...colors,
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],
@@ -31,4 +30,3 @@ const config: Config = {
 }
 
 export default config
-


### PR DESCRIPTION
## Summary

- Add 11 color tokens derived from Pencil design inventory (MU red `#DA291C`, gold `#FFB81C`, dark background palette)
- Add typography tokens (Inter font family, 8 font sizes, 4 font weights)
- Add spacing scale tokens (12 steps, 0–80px)
- Extend `tailwind.config.ts` with MU brand colors (spreads `colors` token map, preserving all existing `primary` shades)
- Add CSS custom properties (`--mu-red-primary`, etc.) to `src/index.css` `:root` block

## Test plan

- [x] 13 unit tests covering: all hex values valid, all expected keys present, correct specific values, typography rem format, spacing rem format
- [x] `npm test -- --run src/styles/tokens` — 1 test file, 13 tests, all pass
- [ ] Verify Tailwind classes like `bg-mu-red-primary` resolve correctly in a component
- [ ] Verify CSS vars are accessible via `var(--mu-red-primary)` in browser DevTools

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)