### PR TITLE
feat(ui): atomic UI components — Button, Badge, Icon, Skeleton, Spinner [REDESIGN-005]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.13.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "lucide-react": "^1.7.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.13.2",
@@ -8145,6 +8146,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "axios": "^1.13.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "lucide-react": "^1.7.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.13.2",

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -1,0 +1,51 @@
+import { type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+const badgeVariants = cva('inline-flex items-center font-semibold rounded-full', {
+  variants: {
+    variant: {
+      /** WIN result — green */
+      win: 'bg-[#10B981] text-white',
+      /** DRAW result — orange */
+      draw: 'bg-[#F59E0B] text-white',
+      /** LOSS result — red */
+      loss: 'bg-[#EF4444] text-white',
+      /** General / neutral dark badge */
+      default: 'bg-[#2A2A2A] text-white',
+      /** MU gold on dark — for competition names, position badges */
+      gold: 'bg-[#FFB81C] text-[#1A1A1A]',
+    },
+    size: {
+      sm: 'text-xs px-2 py-0.5',
+      md: 'text-sm px-2.5 py-0.5',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'sm',
+  },
+})
+
+export interface BadgeProps extends VariantProps<typeof badgeVariants> {
+  children: ReactNode
+  /** Additional className */
+  className?: string
+}
+
+/**
+ * MU-themed badge for match results (WIN/DRAW/LOSS), competition names, and position labels.
+ *
+ * @example
+ * ```tsx
+ * <Badge variant="win">WIN</Badge>
+ * <Badge variant="draw">DRAW</Badge>
+ * <Badge variant="loss">LOSS</Badge>
+ * <Badge variant="gold">Premier League</Badge>
+ * ```
+ */
+export function Badge({ children, variant, size, className }: BadgeProps) {
+  return <span className={cn(badgeVariants({ variant, size }), className)}>{children}</span>
+}
+
+export { badgeVariants }

--- a/src/components/ui/Badge/__tests__/Badge.test.tsx
+++ b/src/components/ui/Badge/__tests__/Badge.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Badge } from '../Badge'
+
+describe('Badge (MU atomic)', () => {
+  describe('Rendering', () => {
+    it('renders children text', () => {
+      render(<Badge>WIN</Badge>)
+      expect(screen.getByText('WIN')).toBeInTheDocument()
+    })
+
+    it('renders as a span element', () => {
+      const { container } = render(<Badge>text</Badge>)
+      expect(container.firstChild?.nodeName).toBe('SPAN')
+    })
+  })
+
+  describe('Variants', () => {
+    it('applies win variant — success green', () => {
+      const { container } = render(<Badge variant="win">WIN</Badge>)
+      expect(container.firstChild).toHaveClass('bg-[#10B981]', 'text-white')
+    })
+
+    it('applies draw variant — warning orange', () => {
+      const { container } = render(<Badge variant="draw">DRAW</Badge>)
+      expect(container.firstChild).toHaveClass('bg-[#F59E0B]', 'text-white')
+    })
+
+    it('applies loss variant — error red', () => {
+      const { container } = render(<Badge variant="loss">LOSS</Badge>)
+      expect(container.firstChild).toHaveClass('bg-[#EF4444]', 'text-white')
+    })
+
+    it('applies default variant — dark bg', () => {
+      const { container } = render(<Badge variant="default">Premier League</Badge>)
+      expect(container.firstChild).toHaveClass('bg-[#2A2A2A]', 'text-white')
+    })
+
+    it('applies gold variant — MU gold on dark text', () => {
+      const { container } = render(<Badge variant="gold">Top 4</Badge>)
+      expect(container.firstChild).toHaveClass('bg-[#FFB81C]', 'text-[#1A1A1A]')
+    })
+
+    it('renders all variants without errors', () => {
+      const variants = ['win', 'draw', 'loss', 'default', 'gold'] as const
+      variants.forEach((variant) => {
+        const { unmount } = render(<Badge variant={variant}>{variant}</Badge>)
+        expect(screen.getByText(variant)).toBeInTheDocument()
+        unmount()
+      })
+    })
+  })
+
+  describe('Sizes', () => {
+    it('applies sm size by default', () => {
+      const { container } = render(<Badge>text</Badge>)
+      expect(container.firstChild).toHaveClass('text-xs', 'px-2')
+    })
+
+    it('applies md size', () => {
+      const { container } = render(<Badge size="md">text</Badge>)
+      expect(container.firstChild).toHaveClass('text-sm', 'px-2.5')
+    })
+  })
+
+  describe('Custom className', () => {
+    it('merges additional className', () => {
+      const { container } = render(<Badge className="extra">text</Badge>)
+      expect(container.firstChild).toHaveClass('extra')
+    })
+  })
+})

--- a/src/components/ui/Badge/index.ts
+++ b/src/components/ui/Badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge, badgeVariants } from './Badge'
+export type { BadgeProps } from './Badge'

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,0 +1,108 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A1A1A] disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-[#DA291C] text-white hover:bg-[#c4251a] focus-visible:ring-[#DA291C]',
+        secondary: 'bg-[#2A2A2A] text-white hover:bg-[#3a3a3a] focus-visible:ring-[#2A2A2A]',
+        ghost: 'bg-transparent text-white hover:bg-[#2A2A2A] focus-visible:ring-[#2A2A2A]',
+        danger: 'bg-[#EF4444] text-white hover:bg-[#dc2626] focus-visible:ring-[#EF4444]',
+      },
+      size: {
+        sm: 'h-8 px-3 text-sm gap-1.5',
+        md: 'h-10 px-4 text-sm gap-2',
+        lg: 'h-12 px-6 text-base gap-2',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  }
+)
+
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  /** Shows loading spinner and disables the button */
+  loading?: boolean
+  /** Icon before the label */
+  leftIcon?: ReactNode
+  /** Icon after the label */
+  rightIcon?: ReactNode
+}
+
+/**
+ * MU-themed button with 4 variants (primary/secondary/ghost/danger), 3 sizes, and loading state.
+ *
+ * @example
+ * ```tsx
+ * <Button variant="primary" size="md">Save</Button>
+ * <Button variant="danger" loading>Deleting...</Button>
+ * <Button variant="ghost" leftIcon={<PlusIcon />}>Add</Button>
+ * ```
+ */
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      variant,
+      size,
+      loading = false,
+      leftIcon,
+      rightIcon,
+      disabled,
+      children,
+      type = 'button',
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        disabled={disabled || loading}
+        aria-disabled={disabled || loading}
+        className={cn(buttonVariants({ variant, size }), className)}
+        {...props}
+      >
+        {loading ? (
+          <svg
+            data-testid="button-spinner"
+            className="w-4 h-4 animate-spin"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
+          </svg>
+        ) : (
+          leftIcon && <span aria-hidden="true">{leftIcon}</span>
+        )}
+        {children}
+        {!loading && rightIcon && <span aria-hidden="true">{rightIcon}</span>}
+      </button>
+    )
+  }
+)
+
+Button.displayName = 'Button'
+
+export { buttonVariants }

--- a/src/components/ui/Button/__tests__/Button.test.tsx
+++ b/src/components/ui/Button/__tests__/Button.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@/tests/utils/test-utils'
+import userEvent from '@testing-library/user-event'
+import { Button } from '../Button'
+
+describe('Button (MU atomic)', () => {
+  describe('Rendering', () => {
+    it('renders a button element', () => {
+      render(<Button>Click me</Button>)
+      expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument()
+    })
+
+    it('renders all variants without errors', () => {
+      const variants = ['primary', 'secondary', 'ghost', 'danger'] as const
+      variants.forEach((variant) => {
+        const { unmount } = render(<Button variant={variant}>{variant}</Button>)
+        expect(screen.getByRole('button')).toBeInTheDocument()
+        unmount()
+      })
+    })
+
+    it('renders all sizes without errors', () => {
+      const sizes = ['sm', 'md', 'lg'] as const
+      sizes.forEach((size) => {
+        const { unmount } = render(<Button size={size}>{size}</Button>)
+        expect(screen.getByRole('button')).toBeInTheDocument()
+        unmount()
+      })
+    })
+
+    it('applies primary variant styles (MU red)', () => {
+      const { container } = render(<Button variant="primary">Primary</Button>)
+      expect(container.firstChild).toHaveClass('bg-[#DA291C]')
+    })
+
+    it('applies secondary variant styles', () => {
+      const { container } = render(<Button variant="secondary">Secondary</Button>)
+      expect(container.firstChild).toHaveClass('bg-[#2A2A2A]')
+    })
+
+    it('applies ghost variant styles', () => {
+      const { container } = render(<Button variant="ghost">Ghost</Button>)
+      expect(container.firstChild).toHaveClass('bg-transparent')
+    })
+
+    it('applies danger variant styles', () => {
+      const { container } = render(<Button variant="danger">Danger</Button>)
+      expect(container.firstChild).toHaveClass('bg-[#EF4444]')
+    })
+  })
+
+  describe('Icons', () => {
+    it('renders left icon', () => {
+      render(<Button leftIcon={<span data-testid="left-icon">←</span>}>Go back</Button>)
+      expect(screen.getByTestId('left-icon')).toBeInTheDocument()
+    })
+
+    it('renders right icon', () => {
+      render(<Button rightIcon={<span data-testid="right-icon">→</span>}>Next</Button>)
+      expect(screen.getByTestId('right-icon')).toBeInTheDocument()
+    })
+
+    it('hides left icon when loading', () => {
+      render(
+        <Button loading leftIcon={<span data-testid="icon">←</span>}>
+          Loading
+        </Button>
+      )
+      expect(screen.queryByTestId('icon')).not.toBeInTheDocument()
+    })
+
+    it('hides right icon when loading', () => {
+      render(
+        <Button loading rightIcon={<span data-testid="right-icon">→</span>}>
+          Loading
+        </Button>
+      )
+      expect(screen.queryByTestId('right-icon')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Loading state', () => {
+    it('shows spinner SVG when loading', () => {
+      render(<Button loading>Saving</Button>)
+      expect(screen.getByTestId('button-spinner')).toBeInTheDocument()
+    })
+
+    it('is disabled when loading', () => {
+      render(<Button loading>Saving</Button>)
+      expect(screen.getByRole('button')).toBeDisabled()
+    })
+
+    it('sets aria-disabled when loading', () => {
+      render(<Button loading>Saving</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true')
+    })
+  })
+
+  describe('Disabled state', () => {
+    it('is disabled when disabled prop is set', () => {
+      render(<Button disabled>Click</Button>)
+      expect(screen.getByRole('button')).toBeDisabled()
+    })
+
+    it('sets aria-disabled when disabled', () => {
+      render(<Button disabled>Click</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true')
+    })
+  })
+
+  describe('Interactions', () => {
+    it('calls onClick when clicked', async () => {
+      const user = userEvent.setup()
+      const handleClick = vi.fn()
+      render(<Button onClick={handleClick}>Click</Button>)
+      await user.click(screen.getByRole('button'))
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call onClick when disabled', async () => {
+      const user = userEvent.setup()
+      const handleClick = vi.fn()
+      render(
+        <Button onClick={handleClick} disabled>
+          Click
+        </Button>
+      )
+      await user.click(screen.getByRole('button'))
+      expect(handleClick).not.toHaveBeenCalled()
+    })
+
+    it('does not call onClick when loading', async () => {
+      const user = userEvent.setup()
+      const handleClick = vi.fn()
+      render(
+        <Button onClick={handleClick} loading>
+          Click
+        </Button>
+      )
+      await user.click(screen.getByRole('button'))
+      expect(handleClick).not.toHaveBeenCalled()
+    })
+
+    it('forwards ref to the button element', () => {
+      const ref = { current: null as HTMLButtonElement | null }
+      render(<Button ref={ref}>Click</Button>)
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement)
+    })
+  })
+
+  describe('Type attribute', () => {
+    it('defaults to type="button"', () => {
+      render(<Button>Click</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+    })
+
+    it('accepts type="submit"', () => {
+      render(<Button type="submit">Submit</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'submit')
+    })
+  })
+
+  describe('Custom className', () => {
+    it('merges custom className', () => {
+      render(<Button className="extra-class">Click</Button>)
+      expect(screen.getByRole('button')).toHaveClass('extra-class')
+    })
+  })
+})

--- a/src/components/ui/Button/index.ts
+++ b/src/components/ui/Button/index.ts
@@ -1,0 +1,2 @@
+export { Button, buttonVariants } from './Button'
+export type { ButtonProps } from './Button'

--- a/src/components/ui/Icon/Icon.tsx
+++ b/src/components/ui/Icon/Icon.tsx
@@ -1,0 +1,46 @@
+import { type LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface IconProps {
+  /** A lucide-react icon component */
+  name: LucideIcon
+  /** Size in pixels — default 20 */
+  size?: number
+  /** CSS color value — defaults to currentColor */
+  color?: string
+  /** Additional className */
+  className?: string
+  /** Accessible label; set aria-hidden when purely decorative */
+  'aria-label'?: string
+  'aria-hidden'?: boolean | 'true' | 'false'
+}
+
+/**
+ * Thin wrapper around lucide-react icons that applies consistent sizing and color.
+ *
+ * @example
+ * ```tsx
+ * import { Trophy } from 'lucide-react'
+ * <Icon name={Trophy} size={24} color="#FFB81C" />
+ * <Icon name={Trophy} aria-label="Trophy" />
+ * ```
+ */
+export function Icon({
+  name: LucideIconComponent,
+  size = 20,
+  color,
+  className,
+  'aria-label': ariaLabel,
+  'aria-hidden': ariaHidden,
+}: IconProps) {
+  return (
+    <LucideIconComponent
+      size={size}
+      color={color}
+      className={cn('inline-block shrink-0', className)}
+      aria-label={ariaLabel}
+      aria-hidden={ariaHidden ?? (ariaLabel ? undefined : true)}
+      data-testid="icon"
+    />
+  )
+}

--- a/src/components/ui/Icon/__tests__/Icon.test.tsx
+++ b/src/components/ui/Icon/__tests__/Icon.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Trophy, Activity, Settings } from 'lucide-react'
+import { Icon } from '../Icon'
+
+describe('Icon (MU atomic)', () => {
+  describe('Rendering', () => {
+    it('renders a lucide icon', () => {
+      render(<Icon name={Trophy} aria-label="Trophy" />)
+      expect(screen.getByTestId('icon')).toBeInTheDocument()
+    })
+
+    it('renders different icon components', () => {
+      const icons = [Trophy, Activity, Settings]
+      icons.forEach((IconComp) => {
+        const { unmount } = render(<Icon name={IconComp} aria-label="icon" />)
+        expect(screen.getByTestId('icon')).toBeInTheDocument()
+        unmount()
+      })
+    })
+  })
+
+  describe('Size prop', () => {
+    it('defaults to size 20', () => {
+      render(<Icon name={Trophy} aria-label="Trophy" />)
+      const el = screen.getByTestId('icon')
+      expect(el).toHaveAttribute('width', '20')
+      expect(el).toHaveAttribute('height', '20')
+    })
+
+    it('applies custom size', () => {
+      render(<Icon name={Trophy} size={32} aria-label="Trophy" />)
+      const el = screen.getByTestId('icon')
+      expect(el).toHaveAttribute('width', '32')
+      expect(el).toHaveAttribute('height', '32')
+    })
+  })
+
+  describe('Color prop', () => {
+    it('applies color via stroke attribute', () => {
+      render(<Icon name={Trophy} color="#FFB81C" aria-label="Trophy" />)
+      const el = screen.getByTestId('icon')
+      expect(el).toHaveAttribute('stroke', '#FFB81C')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('is aria-hidden when no aria-label provided', () => {
+      render(<Icon name={Trophy} />)
+      const el = screen.getByTestId('icon')
+      expect(el).toHaveAttribute('aria-hidden', 'true')
+    })
+
+    it('exposes aria-label when provided', () => {
+      render(<Icon name={Trophy} aria-label="Win trophy" />)
+      const el = screen.getByTestId('icon')
+      expect(el).toHaveAttribute('aria-label', 'Win trophy')
+    })
+  })
+
+  describe('Custom className', () => {
+    it('merges additional className', () => {
+      render(<Icon name={Trophy} className="extra" aria-label="Trophy" />)
+      expect(screen.getByTestId('icon')).toHaveClass('extra')
+    })
+  })
+})

--- a/src/components/ui/Icon/index.ts
+++ b/src/components/ui/Icon/index.ts
@@ -1,0 +1,2 @@
+export { Icon } from './Icon'
+export type { IconProps } from './Icon'

--- a/src/components/ui/Skeleton/Skeleton.tsx
+++ b/src/components/ui/Skeleton/Skeleton.tsx
@@ -1,0 +1,71 @@
+import { cn } from '@/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+const skeletonVariants = cva('bg-[#2A2A2A] rounded animate-[pulse_1.5s_ease-in-out_infinite]', {
+  variants: {
+    variant: {
+      /** Single line of text */
+      text: 'h-4 w-full rounded',
+      /** Card-shaped block */
+      card: 'rounded-xl',
+      /** Circular avatar placeholder */
+      avatar: 'rounded-full',
+      /** Generic rectangle */
+      rect: 'rounded',
+    },
+  },
+  defaultVariants: {
+    variant: 'rect',
+  },
+})
+
+export interface SkeletonProps extends VariantProps<typeof skeletonVariants> {
+  /** Width (e.g. "200px", "50%") */
+  width?: string
+  /** Height (e.g. "40px", "2rem") */
+  height?: string
+  /** Additional className */
+  className?: string
+  /**
+   * Number of text rows to render — only meaningful when variant="text".
+   * @default 1
+   */
+  count?: number
+}
+
+/**
+ * Animated loading placeholder that pulses between opaque and translucent.
+ *
+ * @example
+ * ```tsx
+ * <Skeleton variant="text" count={3} />
+ * <Skeleton variant="avatar" width="48px" height="48px" />
+ * <Skeleton variant="card" width="100%" height="180px" />
+ * ```
+ */
+export function Skeleton({ variant, width, height, className, count = 1 }: SkeletonProps) {
+  if (variant === 'text' && count > 1) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="skeleton-group">
+        {Array.from({ length: count }).map((_, i) => (
+          <div
+            key={i}
+            className={cn(skeletonVariants({ variant }), i === count - 1 && 'w-3/4', className)}
+            style={{ width: i === count - 1 ? undefined : width, height }}
+            aria-hidden="true"
+            data-testid="skeleton"
+          />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={cn(skeletonVariants({ variant }), className)}
+      style={{ width, height }}
+      aria-hidden="true"
+      data-testid="skeleton"
+    />
+  )
+}

--- a/src/components/ui/Skeleton/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/Skeleton/__tests__/Skeleton.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Skeleton } from '../Skeleton'
+
+describe('Skeleton (MU atomic)', () => {
+  describe('Rendering', () => {
+    it('renders a skeleton element', () => {
+      render(<Skeleton />)
+      expect(screen.getByTestId('skeleton')).toBeInTheDocument()
+    })
+
+    it('is aria-hidden', () => {
+      render(<Skeleton />)
+      expect(screen.getByTestId('skeleton')).toHaveAttribute('aria-hidden', 'true')
+    })
+
+    it('applies MU card background color class', () => {
+      render(<Skeleton />)
+      expect(screen.getByTestId('skeleton')).toHaveClass('bg-[#2A2A2A]')
+    })
+
+    it('applies animate pulse class', () => {
+      render(<Skeleton />)
+      // The class uses a custom animation value
+      const el = screen.getByTestId('skeleton')
+      expect(el.className).toMatch(/animate/)
+    })
+  })
+
+  describe('Variants', () => {
+    it('applies text variant', () => {
+      render(<Skeleton variant="text" />)
+      expect(screen.getByTestId('skeleton')).toHaveClass('h-4')
+    })
+
+    it('applies avatar variant — fully rounded', () => {
+      render(<Skeleton variant="avatar" />)
+      expect(screen.getByTestId('skeleton')).toHaveClass('rounded-full')
+    })
+
+    it('applies card variant — extra rounding', () => {
+      render(<Skeleton variant="card" />)
+      expect(screen.getByTestId('skeleton')).toHaveClass('rounded-xl')
+    })
+
+    it('applies rect variant — default rounding', () => {
+      render(<Skeleton variant="rect" />)
+      expect(screen.getByTestId('skeleton')).toHaveClass('rounded')
+    })
+  })
+
+  describe('Count prop (text variant)', () => {
+    it('renders count=1 as a single element by default', () => {
+      render(<Skeleton variant="text" />)
+      expect(screen.getAllByTestId('skeleton')).toHaveLength(1)
+    })
+
+    it('renders multiple skeleton rows when count > 1', () => {
+      render(<Skeleton variant="text" count={3} />)
+      expect(screen.getAllByTestId('skeleton')).toHaveLength(3)
+    })
+
+    it('renders a skeleton-group wrapper when count > 1', () => {
+      render(<Skeleton variant="text" count={3} />)
+      expect(screen.getByTestId('skeleton-group')).toBeInTheDocument()
+    })
+
+    it('makes the last row shorter (3/4 width) for a natural look', () => {
+      render(<Skeleton variant="text" count={2} />)
+      const rows = screen.getAllByTestId('skeleton')
+      expect(rows[rows.length - 1]).toHaveClass('w-3/4')
+    })
+  })
+
+  describe('Dimensions', () => {
+    it('applies width style', () => {
+      render(<Skeleton width="200px" />)
+      expect(screen.getByTestId('skeleton')).toHaveStyle({ width: '200px' })
+    })
+
+    it('applies height style', () => {
+      render(<Skeleton height="60px" />)
+      expect(screen.getByTestId('skeleton')).toHaveStyle({ height: '60px' })
+    })
+  })
+
+  describe('Custom className', () => {
+    it('merges additional className', () => {
+      render(<Skeleton className="extra" />)
+      expect(screen.getByTestId('skeleton')).toHaveClass('extra')
+    })
+  })
+})

--- a/src/components/ui/Skeleton/index.ts
+++ b/src/components/ui/Skeleton/index.ts
@@ -1,0 +1,2 @@
+export { Skeleton } from './Skeleton'
+export type { SkeletonProps } from './Skeleton'

--- a/src/components/ui/Spinner/Spinner.tsx
+++ b/src/components/ui/Spinner/Spinner.tsx
@@ -1,0 +1,59 @@
+import { cn } from '@/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+const spinnerVariants = cva('animate-spin rounded-full border-2 border-t-transparent', {
+  variants: {
+    size: {
+      /** 16px */
+      sm: 'w-4 h-4',
+      /** 24px */
+      md: 'w-6 h-6',
+      /** 32px */
+      lg: 'w-8 h-8',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+})
+
+export interface SpinnerProps extends VariantProps<typeof spinnerVariants> {
+  /** Accessible label for screen readers */
+  label?: string
+  /**
+   * Border color. Defaults to MU red `#DA291C`.
+   * Pass a Tailwind color class or inline style via className.
+   */
+  color?: string
+  /** Additional className applied to the outer wrapper */
+  className?: string
+}
+
+/**
+ * Circular spinning loader. Defaults to MU red (#DA291C).
+ *
+ * @example
+ * ```tsx
+ * <Spinner size="sm" />
+ * <Spinner size="lg" color="#FFB81C" label="Loading standings..." />
+ * ```
+ */
+export function Spinner({
+  size,
+  color = '#DA291C',
+  label = 'Loading...',
+  className,
+}: SpinnerProps) {
+  return (
+    <span role="status" aria-label={label} className={cn('inline-block', className)}>
+      <span
+        className={spinnerVariants({ size })}
+        style={{ borderColor: color, borderTopColor: 'transparent' }}
+        aria-hidden="true"
+        data-testid="spinner"
+      />
+    </span>
+  )
+}
+
+export { spinnerVariants }

--- a/src/components/ui/Spinner/__tests__/Spinner.test.tsx
+++ b/src/components/ui/Spinner/__tests__/Spinner.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Spinner } from '../Spinner'
+
+describe('Spinner (MU atomic)', () => {
+  describe('Rendering', () => {
+    it('renders the status role element', () => {
+      render(<Spinner />)
+      expect(screen.getByRole('status')).toBeInTheDocument()
+    })
+
+    it('renders with default label "Loading..."', () => {
+      render(<Spinner />)
+      expect(screen.getByRole('status', { name: 'Loading...' })).toBeInTheDocument()
+    })
+
+    it('renders with custom label', () => {
+      render(<Spinner label="Fetching scores..." />)
+      expect(screen.getByRole('status', { name: 'Fetching scores...' })).toBeInTheDocument()
+    })
+
+    it('spinner element is aria-hidden', () => {
+      render(<Spinner />)
+      expect(screen.getByTestId('spinner')).toHaveAttribute('aria-hidden', 'true')
+    })
+  })
+
+  describe('Sizes', () => {
+    it('renders sm size (16px / w-4 h-4)', () => {
+      render(<Spinner size="sm" />)
+      expect(screen.getByTestId('spinner')).toHaveClass('w-4', 'h-4')
+    })
+
+    it('renders md size (24px / w-6 h-6) by default', () => {
+      render(<Spinner />)
+      expect(screen.getByTestId('spinner')).toHaveClass('w-6', 'h-6')
+    })
+
+    it('renders lg size (32px / w-8 h-8)', () => {
+      render(<Spinner size="lg" />)
+      expect(screen.getByTestId('spinner')).toHaveClass('w-8', 'h-8')
+    })
+  })
+
+  describe('Color', () => {
+    it('applies MU red (#DA291C) as default border color via style attribute', () => {
+      render(<Spinner />)
+      const spinner = screen.getByTestId('spinner')
+      // happy-dom does not resolve shorthand borderColor in getComputedStyle,
+      // so we inspect the raw style attribute string instead.
+      expect(spinner.getAttribute('style')).toContain('#DA291C')
+    })
+
+    it('applies custom color via style attribute', () => {
+      render(<Spinner color="#FFB81C" />)
+      const spinner = screen.getByTestId('spinner')
+      expect(spinner.getAttribute('style')).toContain('#FFB81C')
+    })
+  })
+
+  describe('Animation', () => {
+    it('applies animate-spin class', () => {
+      render(<Spinner />)
+      expect(screen.getByTestId('spinner')).toHaveClass('animate-spin')
+    })
+  })
+
+  describe('Custom className', () => {
+    it('merges additional className onto the wrapper', () => {
+      render(<Spinner className="extra" />)
+      expect(screen.getByRole('status')).toHaveClass('extra')
+    })
+  })
+})

--- a/src/components/ui/Spinner/index.ts
+++ b/src/components/ui/Spinner/index.ts
@@ -1,0 +1,2 @@
+export { Spinner, spinnerVariants } from './Spinner'
+export type { SpinnerProps } from './Spinner'

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,26 @@
-export {}
+// ─── Atomic UI components (MU redesign) ───────────────────────────────────────
+export * from './Button'
+export * from './Badge'
+export * from './Icon'
+export * from './Skeleton'
+export * from './Spinner'
+
+// ─── Legacy buttons (ButtonGroup, IconButton) ─────────────────────────────────
+export { ButtonGroup } from './buttons/ButtonGroup'
+export type { ButtonGroupProps, ButtonGroupOrientation } from './buttons/ButtonGroup'
+
+export { IconButton } from './buttons/IconButton'
+export type { IconButtonProps } from './buttons/IconButton'
+
+// ─── Legacy feedback (Chip, EmptyState, Toast, ErrorBoundary) ─────────────────
+export { Chip } from './feedback/Chip'
+export type { ChipProps } from './feedback/Chip'
+
+export { EmptyState } from './feedback/EmptyState'
+export type { EmptyStateProps } from './feedback/EmptyState'
+
+export { ToastProvider, useToast } from './feedback/Toast'
+export type { ToastProviderProps, Toast, ToastVariant } from './feedback/Toast'
+
+export { ErrorBoundary } from './feedback/ErrorBoundary'
+export type { ErrorBoundaryProps } from './feedback/ErrorBoundary'

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,19 @@
 @tailwind utilities;
 
 :root {
+  /* MU Brand Design Tokens */
+  --mu-red-primary: #da291c;
+  --mu-red-secondary: #c1232b;
+  --mu-gold: #ffb81c;
+  --bg-dark: #1a1a1a;
+  --bg-card: #2a2a2a;
+  --bg-sidebar: #0e1117;
+  --text-primary: #ffffff;
+  --text-secondary: #b0b0b0;
+  --success-green: #10b981;
+  --warning-orange: #f59e0b;
+  --error-red: #ef4444;
+
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;

--- a/src/styles/tokens/__tests__/tokens.test.ts
+++ b/src/styles/tokens/__tests__/tokens.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { colors } from '../colors'
+import { typography } from '../typography'
+import { spacing } from '../spacing'
+
+const HEX_COLOR_REGEX = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/
+
+describe('Color tokens', () => {
+  const expectedColorKeys: (keyof typeof colors)[] = [
+    'mu-red-primary',
+    'mu-red-secondary',
+    'mu-gold',
+    'bg-dark',
+    'bg-card',
+    'bg-sidebar',
+    'text-primary',
+    'text-secondary',
+    'success-green',
+    'warning-orange',
+    'error-red',
+  ]
+
+  it('exports all expected color token keys', () => {
+    expectedColorKeys.forEach((key) => {
+      expect(colors).toHaveProperty(key)
+    })
+  })
+
+  it('all color tokens are valid hex strings', () => {
+    Object.entries(colors).forEach(([key, value]) => {
+      expect(value, `Token "${key}" should be a valid hex color`).toMatch(HEX_COLOR_REGEX)
+    })
+  })
+
+  it('has correct values for key MU brand colors', () => {
+    expect(colors['mu-red-primary']).toBe('#DA291C')
+    expect(colors['mu-gold']).toBe('#FFB81C')
+    expect(colors['bg-sidebar']).toBe('#0E1117')
+  })
+
+  it('has exactly 11 color tokens', () => {
+    expect(Object.keys(colors)).toHaveLength(11)
+  })
+})
+
+describe('Typography tokens', () => {
+  it('exports fontFamily with sans', () => {
+    expect(typography.fontFamily).toHaveProperty('sans')
+    expect(typography.fontFamily.sans).toContain('Inter')
+  })
+
+  it('exports fontSize with expected sizes', () => {
+    const expectedSizes = ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl']
+    expectedSizes.forEach((size) => {
+      expect(typography.fontSize).toHaveProperty(size)
+    })
+  })
+
+  it('all fontSize values are rem strings', () => {
+    Object.entries(typography.fontSize).forEach(([key, value]) => {
+      expect(value, `fontSize "${key}" should be a rem string`).toMatch(/rem$/)
+    })
+  })
+
+  it('exports fontWeight with expected weights', () => {
+    const expectedWeights = ['normal', 'medium', 'semibold', 'bold']
+    expectedWeights.forEach((weight) => {
+      expect(typography.fontWeight).toHaveProperty(weight)
+    })
+  })
+
+  it('fontWeight values are numeric strings', () => {
+    Object.entries(typography.fontWeight).forEach(([key, value]) => {
+      expect(Number(value), `fontWeight "${key}" should be numeric`).not.toBeNaN()
+    })
+  })
+})
+
+describe('Spacing tokens', () => {
+  it('exports spacing with key 0', () => {
+    expect(spacing[0]).toBe('0')
+  })
+
+  it('exports expected spacing keys', () => {
+    const expectedKeys = [0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20] as const
+    expectedKeys.forEach((key) => {
+      expect(spacing).toHaveProperty(String(key))
+    })
+  })
+
+  it('non-zero spacing values are rem strings', () => {
+    Object.entries(spacing).forEach(([key, value]) => {
+      if (key !== '0') {
+        expect(value, `spacing "${key}" should be a rem string`).toMatch(/rem$/)
+      }
+    })
+  })
+
+  it('has correct value for spacing 4 (base unit)', () => {
+    expect(spacing[4]).toBe('1rem')
+  })
+})

--- a/src/styles/tokens/colors.ts
+++ b/src/styles/tokens/colors.ts
@@ -1,0 +1,15 @@
+export const colors = {
+  'mu-red-primary': '#DA291C',
+  'mu-red-secondary': '#C1232B',
+  'mu-gold': '#FFB81C',
+  'bg-dark': '#1A1A1A',
+  'bg-card': '#2A2A2A',
+  'bg-sidebar': '#0E1117',
+  'text-primary': '#FFFFFF',
+  'text-secondary': '#B0B0B0',
+  'success-green': '#10B981',
+  'warning-orange': '#F59E0B',
+  'error-red': '#EF4444',
+} as const
+
+export type ColorToken = keyof typeof colors

--- a/src/styles/tokens/index.ts
+++ b/src/styles/tokens/index.ts
@@ -1,0 +1,4 @@
+export { colors } from './colors'
+export type { ColorToken } from './colors'
+export { typography } from './typography'
+export { spacing } from './spacing'

--- a/src/styles/tokens/spacing.ts
+++ b/src/styles/tokens/spacing.ts
@@ -1,0 +1,14 @@
+export const spacing = {
+  0: '0',
+  1: '0.25rem', // 4px
+  2: '0.5rem', // 8px
+  3: '0.75rem', // 12px
+  4: '1rem', // 16px
+  5: '1.25rem', // 20px
+  6: '1.5rem', // 24px
+  8: '2rem', // 32px
+  10: '2.5rem', // 40px
+  12: '3rem', // 48px
+  16: '4rem', // 64px
+  20: '5rem', // 80px
+} as const

--- a/src/styles/tokens/typography.ts
+++ b/src/styles/tokens/typography.ts
@@ -1,0 +1,21 @@
+export const typography = {
+  fontFamily: {
+    sans: ['Inter', 'system-ui', 'sans-serif'],
+  },
+  fontSize: {
+    xs: '0.75rem', // 12px
+    sm: '0.875rem', // 14px
+    base: '1rem', // 16px
+    lg: '1.125rem', // 18px
+    xl: '1.25rem', // 20px
+    '2xl': '1.5rem', // 24px
+    '3xl': '1.875rem', // 30px
+    '4xl': '2.25rem', // 36px
+  },
+  fontWeight: {
+    normal: '400',
+    medium: '500',
+    semibold: '600',
+    bold: '700',
+  },
+} as const

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,8 @@
 import type { Config } from 'tailwindcss'
+import { colors } from './src/styles/tokens/colors'
 
 const config: Config = {
-  content: [
-    './index.html',
-    './src/**/*.{js,ts,jsx,tsx}',
-  ],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       colors: {
@@ -21,6 +19,7 @@ const config: Config = {
           900: '#1e3a8a',
           950: '#172554',
         },
+        ...colors,
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],
@@ -31,4 +30,3 @@ const config: Config = {
 }
 
 export default config
-


### PR DESCRIPTION
## Summary

- **Button** — 4 MU-themed variants (`primary` #DA291C, `secondary` #2A2A2A, `ghost`, `danger` #EF4444), 3 sizes (sm/md/lg), loading state with inline spinner, `leftIcon`/`rightIcon` slots, forwarded ref
- **Badge** — 5 variants mapped to match results and labels (`win` #10B981, `draw` #F59E0B, `loss` #EF4444, `default` #2A2A2A, `gold` #FFB81C on dark), sm/md sizes
- **Icon** — thin `lucide-react` wrapper; accepts any `LucideIcon` component, `size` (default 20), `color`, and proper `aria-label` / `aria-hidden` handling; installs `lucide-react` as a dependency
- **Skeleton** — animated loading placeholder; variants: `text` (with `count` prop for multi-row), `card`, `avatar`, `rect`; background `#2A2A2A`; custom `width`/`height`
- **Spinner** — rotating border spinner; 3 sizes (sm 16px, md 24px, lg 32px); default MU red `#DA291C` color via inline style; accessible `role="status"` wrapper
- **`src/components/ui/index.ts`** — unified barrel re-exporting all new atomic components alongside existing legacy ones (ButtonGroup, IconButton, Chip, EmptyState, Toast, ErrorBoundary) with no name collisions

## Test plan

- [x] `npm test -- --run src/components/ui/Button` — 23 tests, all passing
- [x] `npm test -- --run src/components/ui/Badge` — 11 tests, all passing
- [x] `npm test -- --run src/components/ui/Icon` — 8 tests, all passing
- [x] `npm test -- --run src/components/ui/Skeleton` — 15 tests, all passing
- [x] `npm test -- --run src/components/ui/Spinner` — 11 tests, all passing
- [x] No regressions in existing `buttons/Button` (17 tests) or `buttons/IconButton` (10 tests)
- [x] Total: 102 tests passing across 8 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)