### PR TITLE
fix(config): fix ESLint errors and warnings breaking CI [#58]

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import prettierConfig from 'eslint-config-prettier'
 
 export default tseslint.config(
-  { ignores: ['dist', 'storybook-static', 'coverage', 'playwright-report'] },
+  { ignores: ['dist', 'storybook-static', 'coverage', 'playwright-report', 'mocks/'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended, prettierConfig],
     files: ['**/*.{ts,tsx}'],

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -47,5 +47,3 @@ export interface BadgeProps extends VariantProps<typeof badgeVariants> {
 export function Badge({ children, variant, size, className }: BadgeProps) {
   return <span className={cn(badgeVariants({ variant, size }), className)}>{children}</span>
 }
-
-export { badgeVariants }

--- a/src/components/ui/Badge/index.ts
+++ b/src/components/ui/Badge/index.ts
@@ -1,2 +1,2 @@
-export { Badge, badgeVariants } from './Badge'
+export { Badge } from './Badge'
 export type { BadgeProps } from './Badge'

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -104,5 +104,3 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 )
 
 Button.displayName = 'Button'
-
-export { buttonVariants }

--- a/src/components/ui/Button/index.ts
+++ b/src/components/ui/Button/index.ts
@@ -1,2 +1,2 @@
-export { Button, buttonVariants } from './Button'
+export { Button } from './Button'
 export type { ButtonProps } from './Button'

--- a/src/components/ui/Spinner/Spinner.tsx
+++ b/src/components/ui/Spinner/Spinner.tsx
@@ -55,5 +55,3 @@ export function Spinner({
     </span>
   )
 }
-
-export { spinnerVariants }

--- a/src/components/ui/Spinner/index.ts
+++ b/src/components/ui/Spinner/index.ts
@@ -1,2 +1,2 @@
-export { Spinner, spinnerVariants } from './Spinner'
+export { Spinner } from './Spinner'
 export type { SpinnerProps } from './Spinner'

--- a/src/components/ui/buttons/Button/Button.tsx
+++ b/src/components/ui/buttons/Button/Button.tsx
@@ -108,5 +108,3 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 )
 
 Button.displayName = 'Button'
-
-export { buttonVariants }

--- a/src/components/ui/buttons/Button/index.ts
+++ b/src/components/ui/buttons/Button/index.ts
@@ -1,2 +1,2 @@
-export { Button, buttonVariants } from './Button'
+export { Button } from './Button'
 export type { ButtonProps } from './Button'

--- a/src/components/ui/cards/Card/Card.tsx
+++ b/src/components/ui/cards/Card/Card.tsx
@@ -58,4 +58,3 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
 )
 
 Card.displayName = 'Card'
-export { cardVariants }

--- a/src/components/ui/cards/Card/index.ts
+++ b/src/components/ui/cards/Card/index.ts
@@ -1,2 +1,2 @@
-export { Card, cardVariants } from './Card'
+export { Card } from './Card'
 export type { CardProps } from './Card'

--- a/src/components/ui/cards/index.ts
+++ b/src/components/ui/cards/index.ts
@@ -1,4 +1,4 @@
-export { Card, cardVariants } from './Card'
+export { Card } from './Card'
 export type { CardProps } from './Card'
 
 export { CardHeader } from './CardHeader'

--- a/src/components/ui/feedback/Badge/Badge.tsx
+++ b/src/components/ui/feedback/Badge/Badge.tsx
@@ -42,5 +42,3 @@ export interface BadgeProps extends VariantProps<typeof badgeVariants> {
 export function Badge({ children, variant, size, className }: BadgeProps) {
   return <span className={cn(badgeVariants({ variant, size }), className)}>{children}</span>
 }
-
-export { badgeVariants }

--- a/src/components/ui/feedback/Badge/index.ts
+++ b/src/components/ui/feedback/Badge/index.ts
@@ -1,2 +1,2 @@
-export { Badge, badgeVariants } from './Badge'
+export { Badge } from './Badge'
 export type { BadgeProps } from './Badge'

--- a/src/components/ui/feedback/Spinner/Spinner.tsx
+++ b/src/components/ui/feedback/Spinner/Spinner.tsx
@@ -48,5 +48,3 @@ export function Spinner({ size, color, label = 'Loading...', className }: Spinne
     </span>
   )
 }
-
-export { spinnerVariants }

--- a/src/components/ui/feedback/Spinner/index.ts
+++ b/src/components/ui/feedback/Spinner/index.ts
@@ -1,2 +1,2 @@
-export { Spinner, spinnerVariants } from './Spinner'
+export { Spinner } from './Spinner'
 export type { SpinnerProps } from './Spinner'

--- a/src/components/ui/feedback/Toast/Toast.tsx
+++ b/src/components/ui/feedback/Toast/Toast.tsx
@@ -118,6 +118,7 @@ export function ToastProvider({ children }: ToastProviderProps) {
  * addToast('Score updated!', 'success')
  * ```
  */
+// eslint-disable-next-line react-refresh/only-export-components
 export function useToast(): ToastContextValue {
   const ctx = useContext(ToastContext)
   if (!ctx) throw new Error('useToast must be used inside ToastProvider')

--- a/src/components/ui/feedback/index.ts
+++ b/src/components/ui/feedback/index.ts
@@ -1,10 +1,10 @@
-export { Spinner, spinnerVariants } from './Spinner'
+export { Spinner } from './Spinner'
 export type { SpinnerProps } from './Spinner'
 
 export { Skeleton } from './Skeleton'
 export type { SkeletonProps } from './Skeleton'
 
-export { Badge, badgeVariants } from './Badge'
+export { Badge } from './Badge'
 export type { BadgeProps } from './Badge'
 
 export { Chip } from './Chip'

--- a/src/tests/utils/test-utils.tsx
+++ b/src/tests/utils/test-utils.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { type ReactElement } from 'react'
 import { render, type RenderOptions } from '@testing-library/react'
 


### PR DESCRIPTION
## Problem
CI was failing on `npm run lint` with exit code 1:
- **1 error:** `mocks/manchester-united-layout.js` — Pencil design file caused parse error (not valid ESLint-parseable JS)
- **10 warnings:** `react-refresh/only-export-components` — component files also exported `cva` variant functions

## Changes
| File | Fix |
|---|---|
| `eslint.config.js` | Added `mocks/` to `ignores` array |
| `ui/Badge/Badge.tsx` + index | Removed `export { badgeVariants }` (unused externally) |
| `ui/Button/Button.tsx` + index | Removed `export { buttonVariants }` (unused externally) |
| `ui/Spinner/Spinner.tsx` + index | Removed `export { spinnerVariants }` (unused externally) |
| `ui/buttons/Button/Button.tsx` + index | Removed `export { buttonVariants }` (unused externally) |
| `ui/cards/Card/Card.tsx` + index | Removed `export { cardVariants }` (unused externally) |
| `ui/feedback/Badge/Badge.tsx` + index | Removed `export { badgeVariants }` (unused externally) |
| `ui/feedback/Spinner/Spinner.tsx` + index | Removed `export { spinnerVariants }` (unused externally) |
| `ui/feedback/Toast/Toast.tsx` | Added `eslint-disable-next-line` on `useToast` (intentional hook+component pattern) |
| `tests/utils/test-utils.tsx` | Added file-level `eslint-disable` (test utility, not subject to fast-refresh rules) |

## Verification
`npm run lint` → **0 errors, 0 warnings** ✓

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)