### PR TITLE
docs(docs): add Claude Code skills and execution guide

### DIFF
--- a/.claude/guides/EXECUTION_GUIDE.md
+++ b/.claude/guides/EXECUTION_GUIDE.md
@@ -1,0 +1,457 @@
+# 🚀 Instrucciones para Ejecutar el Plan con Claude Code
+
+## 📋 Resumen
+
+Este documento explica cómo usar **Claude Code** para ejecutar el plan de desarrollo del **Sports Dashboard** utilizando las skills creadas y el documento maestro.
+
+---
+
+## 🎯 Prerequisitos
+
+### 1. Repositorio Configurado
+
+```bash
+# Verificar que el repositorio existe y tiene las ramas
+git remote -v
+git branch -a
+
+# Debe mostrar:
+# origin  https://github.com/TU_USUARIO/sports-dashboard.git
+# * develop
+#   main
+```
+
+### 2. Skills Instaladas
+
+Las skills deben estar en el directorio correcto para que Claude pueda acceder a ellas:
+
+```bash
+# Copiar skills al directorio de Claude Code
+cp project-orchestrator-skill.md ~/.claude/skills/
+cp github-flow-executor-skill.md ~/.claude/skills/
+cp component-builder-skill.md ~/.claude/skills/
+cp hook-builder-skill.md ~/.claude/skills/
+cp conventional-commits-skill.md ~/.claude/skills/
+cp design-reader-mcp-skill.md ~/.claude/skills/
+cp code-reviewer-skill.md ~/.claude/skills/
+```
+
+### 3. Archivo Maestro Accesible
+
+El documento `SPORTS_DASHBOARD_MASTER.md` debe estar en la raíz del proyecto o en una ubicación conocida.
+
+---
+
+## 🎬 Iniciando la Ejecución
+
+### Opción 1: Ejecución Completa (Recomendado para Primera Vez)
+
+```bash
+# En Claude Code, ejecutar:
+claude code --project sports-dashboard
+
+# Prompt inicial:
+"Lee el archivo SPORTS_DASHBOARD_MASTER.md y ejecuta el plan completo
+siguiendo la metodología multi-agente. Comienza con la Fase 0: Setup
+y Configuración. Usa las skills disponibles para cada tipo de tarea."
+```
+
+### Opción 2: Ejecución por Fases
+
+```bash
+# Para ejecutar solo una fase específica:
+claude code --project sports-dashboard
+
+# Prompt:
+"Ejecuta únicamente la FASE 1: Design System del plan maestro.
+Usa la skill component-builder para cada componente y sigue el
+flujo de GitHub completo (issue → branch → code → test → PR → merge)."
+```
+
+### Opción 3: Ejecución de Tarea Individual
+
+```bash
+# Para una sola tarea:
+claude code --project sports-dashboard
+
+# Prompt:
+"Ejecuta la tarea TASK-011: Crear componente TextInput.
+Usa las skills: github-flow-executor y component-builder.
+Sigue todos los criterios de aceptación del issue."
+```
+
+---
+
+## 🤖 Modo Orquestador
+
+### Configuración del Orquestador
+
+Cuando Claude Code actúa como orquestador, debe:
+
+1. **Leer el Plan Maestro**
+
+   ```
+   Leer SPORTS_DASHBOARD_MASTER.md completamente
+   Identificar todas las fases y tareas
+   Construir grafo de dependencias
+   ```
+
+2. **Priorizar Tareas**
+
+   ```
+   Ordenar tareas por fase
+   Identificar tareas bloqueantes
+   Marcar tareas que pueden ejecutarse en paralelo
+   ```
+
+3. **Asignar Agentes**
+
+   ```
+   Para cada tarea:
+   - Determinar tipo (componente, hook, service, test, docs)
+   - Asignar agente especializado
+   - Verificar skills necesarias
+   ```
+
+4. **Ejecutar Fase por Fase**
+   ```
+   Para cada fase:
+   - Verificar dependencias completadas
+   - Ejecutar tareas en orden o paralelo
+   - Validar criterios de aceptación
+   - Reportar progreso
+   ```
+
+---
+
+## 📝 Prompts Específicos por Tipo de Tarea
+
+### Para Componentes UI
+
+```
+"Actúa como Component Agent. Crea el componente [NOMBRE] siguiendo
+la skill component-builder. Incluye:
+1. Componente con TypeScript + CVA
+2. Tests unitarios (coverage >80%)
+3. Storybook story con todas las variantes
+4. Sigue el flujo GitHub completo usando github-flow-executor
+5. Usa conventional-commits para los commits
+
+Referencia: TASK-XXX en el documento maestro"
+```
+
+### Para Custom Hooks
+
+```
+"Actúa como Hook Agent. Crea el hook [NOMBRE] siguiendo la skill
+hook-builder. Incluye:
+1. Hook con TypeScript estricto
+2. Manejo de cleanup
+3. Tests exhaustivos (coverage >90%)
+4. JSDoc con ejemplos
+5. Sigue el flujo GitHub completo
+
+Referencia: TASK-XXX en el documento maestro"
+```
+
+### Para Servicios y API
+
+```
+"Actúa como Service Agent. Crea el servicio [NOMBRE] siguiendo
+estas especificaciones:
+1. Cliente HTTP con Axios
+2. Interceptores de request/response
+3. Error handler centralizado
+4. Transformers para normalizar datos
+5. Hooks de React Query
+6. Tests con MSW mocking
+
+Referencia: TASK-XXX en el documento maestro"
+```
+
+### Para Tests E2E
+
+```
+"Actúa como Testing Agent. Crea tests E2E para [FEATURE] usando Playwright:
+1. Page Objects
+2. Test specs para flujos principales
+3. Fixtures y mocks
+4. Configuración en playwright.config.ts
+
+Referencia: TASK-XXX en el documento maestro"
+```
+
+---
+
+## 🔄 Flujo de Ejecución Automática
+
+### Ejemplo de Sesión Completa
+
+```bash
+# 1. Iniciar Claude Code
+claude code --project sports-dashboard
+
+# 2. Prompt de inicio
+>>> "Hola Claude, vamos a desarrollar el Sports Dashboard.
+Lee el archivo SPORTS_DASHBOARD_MASTER.md y actúa como orquestador
+usando la skill project-orchestrator.
+
+Ejecuta las siguientes fases en orden:
+- FASE 0: Setup y Configuración
+- FASE 1: Design System
+
+Para cada tarea:
+1. Crea el issue usando el template de GitHub
+2. Usa la skill apropiada (component-builder, hook-builder, etc.)
+3. Sigue el flujo GitHub completo
+4. Valida con la skill code-reviewer antes de merge
+
+Reporta progreso después de cada tarea completada."
+
+# 3. Claude comenzará a ejecutar
+[Claude] "Entendido. Iniciando ejecución del plan.
+
+=== FASE 0: Setup y Configuración ===
+
+📋 TASK-001: Inicializar proyecto con Vite + React + TypeScript
+
+1️⃣ Creando issue en GitHub...
+   ✅ Issue #1 creado: https://github.com/user/sports-dashboard/issues/1
+
+2️⃣ Creando rama feature/TASK-001-setup-vite...
+   ✅ Rama creada
+
+3️⃣ Implementando...
+   ✅ Vite configurado
+   ✅ React 18.x instalado
+   ✅ TypeScript 5.x configurado
+   ✅ Dev server funcionando
+
+4️⃣ Haciendo commit...
+   ✅ Commit: feat(config): initialize project with vite
+
+5️⃣ Creando PR...
+   ✅ PR #1 creado: https://github.com/user/sports-dashboard/pull/1
+
+6️⃣ Verificando CI...
+   ✅ CI pasando
+
+7️⃣ Mergeando...
+   ✅ PR mergeado y rama eliminada
+
+✅ TASK-001 COMPLETADA (30 minutos)
+
+Continuando con TASK-002..."
+
+# 4. Claude continuará ejecutando todas las tareas
+```
+
+---
+
+## 🎛️ Comandos de Control Durante la Ejecución
+
+### Pausar la Ejecución
+
+```
+>>> "Pausa la ejecución después de completar la tarea actual.
+Muéstrame un resumen del progreso."
+```
+
+### Ver Estado Actual
+
+```
+>>> "Muéstrame el estado actual del proyecto:
+- Tareas completadas
+- Tareas en progreso
+- Tareas pendientes
+- Bloqueos si hay"
+```
+
+### Saltar una Tarea
+
+```
+>>> "Salta la tarea TASK-XXX por ahora y continúa con la siguiente.
+Márcala como bloqueada."
+```
+
+### Reintentar una Tarea
+
+```
+>>> "La tarea TASK-XXX falló. Analiza el error y reintenta con
+una estrategia diferente."
+```
+
+### Generar Reporte
+
+```
+>>> "Genera un reporte de progreso de la FASE 1:
+- Tareas completadas vs pendientes
+- Tiempo real vs estimado
+- Coverage actual
+- Issues bloqueantes"
+```
+
+---
+
+## 📊 Monitoreo del Progreso
+
+### Dashboard en GitHub
+
+Claude puede generar un dashboard de progreso:
+
+```
+>>> "Crea un archivo PROGRESS.md en el repositorio que muestre:
+- Progreso por fase (% completado)
+- Gráfico de burndown
+- Métricas de calidad (coverage, test pass rate)
+- Actualízalo después de cada tarea completada"
+```
+
+### Métricas Clave
+
+Claude debe reportar:
+
+- **Velocidad**: Tareas/hora
+- **Calidad**: % tests passing, coverage promedio
+- **Bloqueos**: Tareas bloqueadas y razones
+- **Estimación**: Tiempo restante estimado
+
+---
+
+## 🚨 Manejo de Errores
+
+### Si CI Falla
+
+```
+>>> "El CI falló en el PR #X. Analiza los logs, identifica el problema,
+corrígelo y push de nuevo. Usa git commit --amend si es un fix menor."
+```
+
+### Si Tests Fallan
+
+```
+>>> "Los tests de TASK-XXX están fallando. Revisa los tests, corrige
+el código o los tests según sea necesario, y asegúrate de que el
+coverage sea >80%."
+```
+
+### Si Hay Conflictos de Merge
+
+```
+>>> "Hay conflictos en el PR #X. Resuelve los conflictos manteniendo
+los cambios más recientes de develop y preservando la funcionalidad
+de mi rama."
+```
+
+---
+
+## 📚 Recursos Adicionales
+
+### Documentos a Consultar
+
+Durante la ejecución, Claude debe consultar:
+
+- `SPORTS_DASHBOARD_MASTER.md` - Plan maestro
+- `.github/ISSUE_TEMPLATE/task.yml` - Template de issues
+- `.github/pull_request_template.md` - Template de PRs
+- Skills en `~/.claude/skills/` - Guías de implementación
+
+### Comandos Git Útiles
+
+```bash
+# Ver estado actual
+git status
+git log --oneline -10
+
+# Ver branches
+git branch -a
+
+# Ver issues y PRs
+gh issue list
+gh pr list
+
+# Ver progreso de CI
+gh run list
+gh run view
+```
+
+---
+
+## ✅ Checklist de Ejecución Exitosa
+
+Después de cada fase:
+
+- [ ] Todas las tareas completadas
+- [ ] Todos los PRs mergeados
+- [ ] CI verde en develop
+- [ ] Coverage global >80%
+- [ ] Documentación actualizada
+- [ ] No hay tareas bloqueadas sin resolver
+
+---
+
+## 🎯 Ejemplo: Ejecutar Solo Setup (Fase 0)
+
+```bash
+claude code --project sports-dashboard
+
+>>> "
+Ejecuta solo la FASE 0: Setup y Configuración del documento maestro.
+
+Tareas a completar (TASK-001 a TASK-010):
+1. Inicializar proyecto con Vite
+2. Configurar Tailwind CSS
+3. Configurar ESLint + Prettier
+4. Configurar Husky + lint-staged
+5. Configurar Vitest + Testing Library
+6. Configurar Storybook
+7. Crear estructura de carpetas base
+8. Configurar path aliases
+9. Crear .env.example
+10. Configurar MSW para mocking
+
+Para cada tarea:
+- Usa github-flow-executor skill
+- Sigue conventional-commits
+- Crea issue, branch, implementa, test, PR, merge
+
+Estimación total: 6-8 horas
+Reporta progreso cada 2 tareas.
+"
+
+# Claude ejecutará las 10 tareas automáticamente
+# Al finalizar, reportará:
+✅ FASE 0 COMPLETADA
+- 10/10 tareas completadas
+- 7.2 horas reales vs 8h estimadas
+- 0 errores bloqueantes
+- Develop actualizado y CI verde
+
+¿Deseas continuar con FASE 1: Design System?
+```
+
+---
+
+## 🎓 Tips para Ejecución Óptima
+
+1. **Sé Específico**: Indica claramente qué fase o tarea ejecutar
+2. **Usa Skills**: Menciona qué skills usar para cada tipo de tarea
+3. **Monitorea CI**: Pide a Claude que verifique CI antes de continuar
+4. **Valida Coverage**: Asegúrate de que el coverage no baje
+5. **Reportes Periódicos**: Solicita reportes de progreso regularmente
+6. **Backup**: Haz backup antes de fases críticas (merge a main)
+
+---
+
+## 📞 Contacto y Ayuda
+
+Si encuentras problemas durante la ejecución:
+
+1. Pausa la ejecución
+2. Revisa los logs de CI/CD
+3. Consulta el documento maestro
+4. Pide a Claude que analice el error específico
+
+---
+
+**¡Listo para ejecutar! 🚀**

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,171 @@
+# 📚 Sports Dashboard - Skills Directory
+
+Todas las skills especializadas para el desarrollo del proyecto Sports Dashboard.
+
+## 📁 Estructura
+
+```
+skills/
+├── orchestration/       # Orquestación y planificación
+│   ├── project-orchestrator.md
+│   ├── task-planner.md
+│   └── milestone-tracker.md
+├── github/              # Flujos de GitHub
+│   ├── github-flow-executor.md
+│   ├── conventional-commits.md
+│   ├── pr-creator.md
+│   └── issue-creator.md
+├── development/         # Construcción de código
+│   ├── component-builder.md
+│   ├── hook-builder.md
+│   └── service-builder.md
+├── testing/             # Testing y calidad
+│   ├── test-generator.md
+│   ├── test-coverage-validator.md
+│   └── accessibility-checker.md
+├── design/              # Diseño y UI
+│   ├── design-reader-mcp.md
+│   ├── design-system-builder.md
+│   └── tailwind-composer.md
+├── quality/             # Code review
+│   └── code-reviewer.md
+└── documentation/       # Documentación
+    ├── storybook-story-generator.md
+    ├── jsdoc-generator.md
+    └── architecture-documenter.md
+```
+
+## 🎯 Skills por Categoría
+
+### 🎭 Orchestration (3 skills)
+
+Coordinación de proyectos y planificación estratégica.
+
+| Skill                    | Descripción                                       | Cuándo Usar              |
+| ------------------------ | ------------------------------------------------- | ------------------------ |
+| **project-orchestrator** | Coordina multi-agentes y ejecuta planes complejos | Proyectos >50 tareas     |
+| **task-planner**         | Descompone épicas en tareas atómicas              | Planificación de sprints |
+| **milestone-tracker**    | Rastrea progreso y detecta bloqueos               | Reportes de progreso     |
+
+### 🔄 GitHub (4 skills)
+
+Flujos de trabajo con Git y GitHub.
+
+| Skill                    | Descripción                        | Cuándo Usar              |
+| ------------------------ | ---------------------------------- | ------------------------ |
+| **github-flow-executor** | Flujo completo: issue → PR → merge | Cada tarea de desarrollo |
+| **conventional-commits** | Commits con formato convencional   | Cada commit              |
+| **pr-creator**           | Crea PRs con templates             | Al completar tarea       |
+| **issue-creator**        | Crea issues con criterios          | Planificación de backlog |
+
+### 💻 Development (3 skills)
+
+Construcción de componentes, hooks y servicios.
+
+| Skill                 | Descripción                 | Cuándo Usar                |
+| --------------------- | --------------------------- | -------------------------- |
+| **component-builder** | Componentes React completos | Crear componentes UI       |
+| **hook-builder**      | Custom hooks con tests      | Abstraer lógica compartida |
+| **service-builder**   | Servicios con interceptores | Integrar APIs              |
+
+### 🧪 Testing (3 skills)
+
+Generación y validación de tests.
+
+| Skill                       | Descripción                 | Cuándo Usar            |
+| --------------------------- | --------------------------- | ---------------------- |
+| **test-generator**          | Tests unitarios exhaustivos | Después de implementar |
+| **test-coverage-validator** | Valida coverage >80%        | En CI, antes de merge  |
+| **accessibility-checker**   | Valida WCAG 2.1 AA          | Componentes UI         |
+
+### 🎨 Design (3 skills)
+
+Diseño, tokens y componentes visuales.
+
+| Skill                     | Descripción                    | Cuándo Usar             |
+| ------------------------- | ------------------------------ | ----------------------- |
+| **design-reader-mcp**     | Lee diseños desde Figma/Pencil | Antes de implementar UI |
+| **design-system-builder** | Construye design system        | Inicio del proyecto     |
+| **tailwind-composer**     | Genera clases Tailwind         | Implementar componentes |
+
+### ✅ Quality (1 skill)
+
+Code review y validación.
+
+| Skill             | Descripción              | Cuándo Usar |
+| ----------------- | ------------------------ | ----------- |
+| **code-reviewer** | Valida contra estándares | Revisar PRs |
+
+### 📚 Documentation (3 skills)
+
+Generación de documentación.
+
+| Skill                         | Descripción              | Cuándo Usar            |
+| ----------------------------- | ------------------------ | ---------------------- |
+| **storybook-story-generator** | Stories de Storybook     | Documentar componentes |
+| **jsdoc-generator**           | JSDoc completo           | Documentar APIs        |
+| **architecture-documenter**   | ADRs y docs arquitectura | Decisiones importantes |
+
+## 🚀 Uso con Claude Code
+
+### Ejecución Completa
+
+```bash
+claude code --project sports-dashboard
+
+"Lee SPORTS_DASHBOARD_MASTER.md y ejecuta el plan completo usando
+la skill project-orchestrator"
+```
+
+### Por Fases
+
+```bash
+"Ejecuta FASE 1: Design System usando component-builder y github-flow-executor"
+```
+
+### Tarea Individual
+
+```bash
+"Ejecuta TASK-011 usando component-builder"
+```
+
+## 📖 Guías
+
+- **Guía de Ejecución**: `/guides/EXECUTION_GUIDE.md`
+- **Documento Maestro**: `/SPORTS_DASHBOARD_MASTER.md`
+
+## 🔗 Flujo Típico
+
+```
+1. task-planner → Descompone épica
+2. issue-creator → Crea issues en GitHub
+3. project-orchestrator → Coordina ejecución
+4. component-builder / hook-builder / service-builder → Implementa
+5. test-generator → Genera tests
+6. storybook-story-generator → Documenta
+7. code-reviewer → Valida calidad
+8. github-flow-executor → PR y merge
+9. milestone-tracker → Reporta progreso
+```
+
+## 📊 Métricas por Skill
+
+| Skill                | Complejidad | Tiempo Típico |
+| -------------------- | ----------- | ------------- |
+| project-orchestrator | Alta        | Variable      |
+| github-flow-executor | Media       | 15-20min      |
+| component-builder    | Media       | 1.5-3h        |
+| hook-builder         | Media       | 1-2h          |
+| service-builder      | Alta        | 2-3h          |
+| test-generator       | Baja        | 30-60min      |
+| code-reviewer        | Media       | 10-15min      |
+
+## ✅ Total de Skills
+
+- **20 skills** (todas implementadas)
+- Organizadas en 7 categorías
+- Listas para usar con Claude Code
+
+---
+
+**Para empezar:** Ver `/guides/EXECUTION_GUIDE.md`

--- a/.claude/skills/design/design-reader-mcp.md
+++ b/.claude/skills/design/design-reader-mcp.md
@@ -1,0 +1,345 @@
+# Design Reader MCP Skill
+
+## 📋 Descripción
+
+Lee y extrae especificaciones de diseño desde MCP servers (Figma, Pencil, etc.) para implementar componentes y layouts con precisión pixel-perfect.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Antes de implementar componentes UI
+- Para obtener design tokens (colores, tipografía, espaciado)
+- Cuando hay mockups o wireframes en Figma/Pencil
+- Para mantener consistencia visual con diseños
+
+## 🔌 MCP Servers Compatibles
+
+| Server        | Propósito                 | Capacidades                  |
+| ------------- | ------------------------- | ---------------------------- |
+| **Figma**     | Diseños UI/UX             | Componentes, estilos, assets |
+| **Pencil**    | Wireframes                | Layouts, flujos, mockups     |
+| **BioRender** | Ilustraciones científicas | Diagramas técnicos           |
+| **Canva**     | Gráficos marketing        | Visuales, banners            |
+
+## 📖 Flujo de Lectura de Diseño
+
+```
+1. CONECTAR MCP
+   ├─ Verificar servidor disponible
+   └─ Autenticar si es necesario
+
+2. BUSCAR DISEÑO
+   ├─ Por nombre de proyecto
+   ├─ Por URL de archivo
+   └─ Por componente específico
+
+3. EXTRAER INFORMACIÓN
+   ├─ Design tokens (colores, tipografía)
+   ├─ Componentes y variantes
+   ├─ Dimensiones y espaciado
+   ├─ Assets (íconos, imágenes)
+   └─ Estados (hover, active, disabled)
+
+4. TRANSFORMAR A CÓDIGO
+   ├─ Generar Tailwind classes
+   ├─ Crear variantes con CVA
+   ├─ Definir tokens CSS
+   └─ Exportar assets
+
+5. VALIDAR
+   ├─ Verificar dimensiones
+   ├─ Comprobar accesibilidad (contraste)
+   └─ Confirmar responsive
+```
+
+## 🔧 Uso con Figma MCP
+
+### Conectar y Buscar
+
+```typescript
+// 1. Buscar archivo de diseño
+const designs = await figma.searchFiles({
+  query: 'Sports Dashboard Design System',
+})
+
+// 2. Obtener componentes del archivo
+const components = await figma.getFileComponents({
+  fileKey: designs[0].key,
+})
+
+// 3. Filtrar componente específico
+const buttonComponent = components.find((c) => c.name === 'Button/Primary')
+```
+
+### Extraer Design Tokens
+
+```typescript
+// Obtener estilos del componente
+const componentStyles = await figma.getComponentStyles({
+  fileKey: fileKey,
+  componentId: buttonComponent.id,
+})
+
+// Extraer colores
+const colors = {
+  primary: componentStyles.fills[0].color, // { r, g, b, a }
+  hover: componentStyles.effects.find((e) => e.type === 'DROP_SHADOW')?.color,
+}
+
+// Extraer tipografía
+const typography = {
+  fontFamily: componentStyles.fontFamily,
+  fontSize: componentStyles.fontSize,
+  fontWeight: componentStyles.fontWeight,
+  lineHeight: componentStyles.lineHeight,
+  letterSpacing: componentStyles.letterSpacing,
+}
+
+// Extraer espaciado
+const spacing = {
+  paddingX: componentStyles.paddingLeft, // px
+  paddingY: componentStyles.paddingTop,
+  borderRadius: componentStyles.cornerRadius,
+}
+```
+
+### Transformar a Tailwind
+
+```typescript
+function rgbToTailwind(color: { r: number; g: number; b: number }): string {
+  const r = Math.round(color.r * 255)
+  const g = Math.round(color.g * 255)
+  const b = Math.round(color.b * 255)
+
+  return `rgb(${r}, ${g}, ${b})`
+}
+
+// Generar config de Tailwind
+const tailwindConfig = {
+  colors: {
+    primary: {
+      500: rgbToTailwind(colors.primary),
+      600: rgbToTailwind(colors.hover),
+    },
+  },
+  fontSize: {
+    button: [`${typography.fontSize}px`, typography.lineHeight],
+  },
+  borderRadius: {
+    button: `${spacing.borderRadius}px`,
+  },
+  padding: {
+    'button-x': `${spacing.paddingX}px`,
+    'button-y': `${spacing.paddingY}px`,
+  },
+}
+```
+
+### Generar Componente
+
+```typescript
+// Basado en specs de Figma, generar:
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-button font-medium transition-colors',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-primary-500 text-white hover:bg-primary-600',
+        // ... otras variantes del diseño
+      },
+      size: {
+        md: 'h-10 px-button-x py-button-y text-button',
+        // ... otros tamaños del diseño
+      },
+    },
+  }
+)
+```
+
+## 🎨 Extracción de Assets
+
+```typescript
+// Exportar íconos SVG
+const icons = await figma.getComponentAssets({
+  componentId: iconComponent.id,
+  format: 'svg',
+  scale: 1,
+})
+
+// Guardar en proyecto
+await saveFile({
+  path: 'public/assets/icons/chevron-down.svg',
+  content: icons.svg,
+})
+
+// Exportar imágenes
+const images = await figma.getComponentAssets({
+  componentId: logoComponent.id,
+  format: 'png',
+  scale: 2, // @2x para retina
+})
+
+await saveFile({
+  path: 'public/assets/images/logo@2x.png',
+  content: images.png,
+})
+```
+
+## 📐 Validación de Diseño
+
+```typescript
+// Verificar contraste de accesibilidad (WCAG AA)
+function checkContrast(fg: RGB, bg: RGB): boolean {
+  const contrast = calculateContrastRatio(fg, bg)
+  return contrast >= 4.5 // WCAG AA para texto normal
+}
+
+if (!checkContrast(colors.primary, colors.background)) {
+  console.warn('⚠️  Contraste insuficiente para accesibilidad')
+}
+
+// Verificar dimensiones responsive
+const breakpoints = {
+  mobile: await figma.getComponentVariant({ name: 'Button/Primary/Mobile' }),
+  tablet: await figma.getComponentVariant({ name: 'Button/Primary/Tablet' }),
+  desktop: await figma.getComponentVariant({ name: 'Button/Primary/Desktop' }),
+}
+```
+
+## 📚 Ejemplo Completo: Button Component
+
+```typescript
+// 1. Buscar diseño en Figma
+const file = await figma.searchFiles({ query: 'Design System' })
+const buttons = await figma.getComponents({
+  fileKey: file[0].key,
+  filter: 'Button',
+})
+
+// 2. Extraer todas las variantes
+const variants = {
+  primary: await figma.getComponentStyles({ id: buttons.primary.id }),
+  secondary: await figma.getComponentStyles({ id: buttons.secondary.id }),
+  outline: await figma.getComponentStyles({ id: buttons.outline.id }),
+}
+
+// 3. Generar código
+const generatedComponent = `
+import { cva } from 'class-variance-authority';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md font-medium transition-colors',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-[${rgbToTailwind(variants.primary.fill)}] text-white hover:bg-[${rgbToTailwind(variants.primary.hover)}]',
+        secondary: 'bg-[${rgbToTailwind(variants.secondary.fill)}] text-gray-900 hover:bg-[${rgbToTailwind(variants.secondary.hover)}]',
+        outline: 'border border-gray-300 bg-transparent hover:bg-gray-50'
+      },
+      size: {
+        sm: 'h-8 px-3 text-sm',
+        md: 'h-10 px-4 text-sm',
+        lg: 'h-12 px-6 text-base'
+      }
+    }
+  }
+);
+`
+
+// 4. Guardar componente
+await saveFile({
+  path: 'src/components/ui/buttons/Button/Button.tsx',
+  content: generatedComponent,
+})
+```
+
+## 🔄 Sincronización Continua
+
+```typescript
+// Detectar cambios en diseño de Figma
+const lastSync = await getLastSyncTimestamp()
+
+const updates = await figma.getFileVersions({
+  fileKey: fileKey,
+  since: lastSync,
+})
+
+if (updates.length > 0) {
+  console.log(`🔄 ${updates.length} cambios detectados en Figma`)
+
+  // Re-generar componentes afectados
+  for (const update of updates) {
+    const affectedComponents = await figma.getChangedComponents({
+      versionId: update.id,
+    })
+
+    for (const component of affectedComponents) {
+      await regenerateComponent(component)
+    }
+  }
+}
+```
+
+## ✅ Checklist de Extracción
+
+- [ ] Colores extraídos y mapeados a Tailwind
+- [ ] Tipografía configurada (familia, tamaños, pesos)
+- [ ] Espaciado y padding definidos
+- [ ] Border radius configurado
+- [ ] Sombras (box-shadow) extraídas
+- [ ] Estados (hover, active, disabled) capturados
+- [ ] Assets exportados (SVG @1x, PNG @2x)
+- [ ] Contraste verificado (WCAG AA mínimo)
+- [ ] Breakpoints responsive definidos
+
+## 🚨 Casos Especiales
+
+### Componentes con Múltiples Estados
+
+```typescript
+// Extraer todos los estados de un botón
+const states = {
+  default: await figma.getComponent({ name: 'Button/Primary/Default' }),
+  hover: await figma.getComponent({ name: 'Button/Primary/Hover' }),
+  active: await figma.getComponent({ name: 'Button/Primary/Active' }),
+  disabled: await figma.getComponent({ name: 'Button/Primary/Disabled' }),
+  loading: await figma.getComponent({ name: 'Button/Primary/Loading' }),
+}
+
+// Generar clases para cada estado
+const stateClasses = {
+  default: extractClasses(states.default),
+  hover: `hover:${extractClasses(states.hover)}`,
+  active: `active:${extractClasses(states.active)}`,
+  disabled: `disabled:${extractClasses(states.disabled)}`,
+}
+```
+
+### Design Tokens Globales
+
+```typescript
+// Extraer tokens de colores primarios
+const colorTokens = await figma.getColorStyles({ fileKey })
+
+const tailwindColors = Object.fromEntries(
+  colorTokens.map((token) => [
+    token.name.toLowerCase().replace(' ', '-'),
+    rgbToTailwind(token.color),
+  ])
+)
+
+// Guardar en tailwind.config.ts
+updateTailwindConfig({
+  theme: {
+    extend: {
+      colors: tailwindColors,
+    },
+  },
+})
+```
+
+## 🔗 Skills Relacionadas
+
+- `component-builder` - Usa diseños para construir componentes
+- `design-system-builder` - Construye design system completo
+- `tailwind-composer` - Genera clases Tailwind desde diseño

--- a/.claude/skills/design/design-system-builder.md
+++ b/.claude/skills/design/design-system-builder.md
@@ -1,0 +1,95 @@
+# Design System Builder Skill
+
+## 📋 Descripción
+
+Construye un design system completo desde especificaciones de diseño con design tokens, componentes base y documentación.
+
+## 🎯 Cuándo Usar
+
+- Al inicio del proyecto
+- Para crear componentes base
+- Implementar design tokens
+
+## 🎨 Design Tokens
+
+```typescript
+// tailwind.config.ts
+export default {
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#eff6ff',
+          100: '#dbeafe',
+          // ... hasta 900
+        },
+        // Extraídos desde Figma/diseño
+      },
+      fontSize: {
+        xs: ['0.75rem', { lineHeight: '1rem' }],
+        sm: ['0.875rem', { lineHeight: '1.25rem' }],
+        // ...
+      },
+      spacing: {
+        // Sistema de 8px
+      },
+      borderRadius: {
+        // Radios consistentes
+      },
+    },
+  },
+}
+```
+
+## 📦 Componentes Base
+
+### Inputs
+
+- TextInput
+- SearchInput
+- SelectInput
+- DatePicker
+- Toggle
+
+### Buttons
+
+- Button
+- IconButton
+- ButtonGroup
+
+### Cards
+
+- Card (base)
+- CardHeader
+- CardBody
+- CardFooter
+
+### Feedback
+
+- Spinner
+- Skeleton
+- Toast
+- Badge
+- Chip
+
+### Layout
+
+- Container
+- Grid
+- Flex
+- Stack
+
+## 📚 Documentación
+
+Cada componente debe tener:
+
+- Storybook story con todas las variantes
+- JSDoc completo
+- Ejemplos de uso
+- Guía de accesibilidad
+
+## 🔗 Skills Relacionadas
+
+- `design-reader-mcp` - Extrae tokens desde diseño
+- `component-builder` - Construye cada componente
+- `tailwind-composer` - Genera clases Tailwind

--- a/.claude/skills/design/tailwind-composer.md
+++ b/.claude/skills/design/tailwind-composer.md
@@ -1,0 +1,99 @@
+# Tailwind Composer Skill
+
+## 📋 Descripción
+
+Genera clases Tailwind consistentes desde especificaciones de diseño.
+
+## 🎯 Cuándo Usar
+
+- Al implementar componentes desde diseños
+- Para mantener consistencia visual
+- Generar variantes
+
+## 🎨 Patrones de Composición
+
+### CVA (Class Variance Authority)
+
+```typescript
+import { cva } from 'class-variance-authority'
+
+const buttonVariants = cva(
+  // Base classes - siempre aplicadas
+  'inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-primary-600 text-white hover:bg-primary-700',
+        secondary: 'bg-gray-100 text-gray-900 hover:bg-gray-200',
+        outline: 'border border-gray-300 bg-transparent hover:bg-gray-50',
+      },
+      size: {
+        sm: 'h-8 px-3 text-sm',
+        md: 'h-10 px-4 text-sm',
+        lg: 'h-12 px-6 text-base',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  }
+)
+```
+
+### cn() Helper
+
+```typescript
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+// Uso
+<button className={cn(
+  buttonVariants({ variant, size }),
+  fullWidth && 'w-full',
+  className
+)} />
+```
+
+## 📐 Sistema de Espaciado
+
+```typescript
+// Usar sistema de 4px/8px
+padding: {
+  '0': '0',
+  '1': '0.25rem',  // 4px
+  '2': '0.5rem',   // 8px
+  '3': '0.75rem',  // 12px
+  '4': '1rem',     // 16px
+  // ...
+}
+```
+
+## 🎯 Mejores Prácticas
+
+1. **Usar variables CSS para colores dinámicos**
+
+```typescript
+className = 'bg-[rgb(var(--color-primary))]'
+```
+
+2. **Grupos de hover/focus/active**
+
+```typescript
+className = 'group-hover:bg-gray-100 group-focus:ring-2'
+```
+
+3. **Responsive con mobile-first**
+
+```typescript
+className = 'text-sm md:text-base lg:text-lg'
+```
+
+## 🔗 Skills Relacionadas
+
+- `component-builder` - Usa Tailwind Composer
+- `design-reader-mcp` - Extrae specs de diseño

--- a/.claude/skills/development/component-builder.md
+++ b/.claude/skills/development/component-builder.md
@@ -1,0 +1,386 @@
+# Component Builder Skill
+
+## 📋 Descripción
+
+Construye componentes React completos siguiendo los estándares del proyecto: TypeScript + Tailwind + CVA + Tests + Storybook + JSDoc.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Crear cualquier componente del design system
+- Componentes de features (ScoreCard, StandingsTable, etc.)
+- Necesitas garantizar calidad y consistencia
+- Componentes reutilizables de UI
+
+## 📁 Estructura de Archivos
+
+```
+src/components/ui/buttons/Button/
+├── Button.tsx           # Componente principal
+├── Button.test.tsx      # Tests unitarios
+├── Button.stories.tsx   # Storybook stories
+└── index.ts             # Barrel export
+```
+
+## 🏗️ Template de Componente
+
+````typescript
+// Button.tsx
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+/**
+ * Variantes del componente usando CVA
+ */
+const buttonVariants = cva(
+  // Estilos base
+  'inline-flex items-center justify-center rounded-md font-medium transition-colors',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-primary-600 text-white hover:bg-primary-700',
+        secondary: 'bg-gray-100 text-gray-900 hover:bg-gray-200',
+      },
+      size: {
+        sm: 'h-8 px-3 text-sm',
+        md: 'h-10 px-4 text-sm',
+        lg: 'h-12 px-6 text-base',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  }
+);
+
+/**
+ * Props del componente
+ */
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  /** Muestra un spinner y deshabilita el botón */
+  loading?: boolean;
+  /** Ocupa todo el ancho disponible */
+  fullWidth?: boolean;
+}
+
+/**
+ * Botón principal de la aplicación
+ *
+ * @example
+ * ```tsx
+ * <Button variant="primary" size="md">
+ *   Click me
+ * </Button>
+ * ```
+ */
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      variant,
+      size,
+      loading = false,
+      fullWidth = false,
+      disabled,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          buttonVariants({ variant, size }),
+          fullWidth && 'w-full',
+          className
+        )}
+        disabled={disabled || loading}
+        {...props}
+      >
+        {loading && <Spinner size="sm" className="mr-2" />}
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';
+````
+
+## 🧪 Template de Tests
+
+```typescript
+// Button.test.tsx
+import { render, screen } from '@/tests/utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { Button } from './Button';
+
+describe('Button', () => {
+  // ═══════════════════════════════════════════════════════════
+  // RENDERING
+  // ═══════════════════════════════════════════════════════════
+  describe('Rendering', () => {
+    it('renders with default props', () => {
+      render(<Button>Click me</Button>);
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    it('renders all variants correctly', () => {
+      const variants = ['primary', 'secondary'] as const;
+      variants.forEach((variant) => {
+        const { unmount } = render(<Button variant={variant}>{variant}</Button>);
+        expect(screen.getByRole('button')).toBeInTheDocument();
+        unmount();
+      });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // INTERACTIONS
+  // ═══════════════════════════════════════════════════════════
+  describe('Interactions', () => {
+    it('calls onClick when clicked', async () => {
+      const user = userEvent.setup();
+      const handleClick = vi.fn();
+      render(<Button onClick={handleClick}>Click me</Button>);
+      await user.click(screen.getByRole('button'));
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClick when disabled', async () => {
+      const user = userEvent.setup();
+      const handleClick = vi.fn();
+      render(<Button onClick={handleClick} disabled>Click me</Button>);
+      await user.click(screen.getByRole('button'));
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // ACCESSIBILITY
+  // ═══════════════════════════════════════════════════════════
+  describe('Accessibility', () => {
+    it('is focusable via keyboard', async () => {
+      const user = userEvent.setup();
+      render(<Button>Click me</Button>);
+      await user.tab();
+      expect(screen.getByRole('button')).toHaveFocus();
+    });
+  });
+});
+```
+
+## 📖 Template de Storybook
+
+```typescript
+// Button.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'UI/Buttons/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    children: 'Primary Button',
+    variant: 'primary',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    children: 'Secondary Button',
+    variant: 'secondary',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <Button variant="primary">Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+    </div>
+  ),
+};
+```
+
+## ✅ Checklist de Implementación
+
+### Código
+
+- [ ] TypeScript sin errores (`tsc --noEmit`)
+- [ ] ESLint sin warnings (`npm run lint`)
+- [ ] Prettier formateado (`npm run format`)
+- [ ] Props tipadas con `interface`
+- [ ] JSDoc en todas las props públicas
+- [ ] Soporte para `className` adicional
+- [ ] `forwardRef` si el componente acepta ref
+- [ ] `displayName` definido
+
+### Variantes (CVA)
+
+- [ ] Variantes definidas con CVA
+- [ ] `defaultVariants` especificadas
+- [ ] Estilos base en string inicial
+- [ ] Uso de `cn()` para merge de clases
+
+### Accesibilidad
+
+- [ ] ARIA labels donde apliquen
+- [ ] Roles semánticos (`button`, `dialog`, etc.)
+- [ ] Focus visible (outline)
+- [ ] Navegación por teclado funcional
+- [ ] Estados disabled correctos
+
+### Testing
+
+- [ ] Tests de rendering (todas las variantes)
+- [ ] Tests de interacciones (click, hover, etc.)
+- [ ] Tests de accesibilidad (keyboard navigation)
+- [ ] Tests de estados (loading, disabled, error)
+- [ ] Coverage >80%
+
+### Storybook
+
+- [ ] Story con todas las variantes
+- [ ] Controles interactivos (`argTypes`)
+- [ ] Documentación con `docs` addon
+- [ ] Tag `autodocs` habilitado
+- [ ] Ejemplos de uso (`AllVariants`, `AllSizes`, etc.)
+
+## 🔧 Comandos
+
+```bash
+# Crear estructura de archivos
+mkdir -p src/components/ui/buttons/Button
+touch src/components/ui/buttons/Button/{Button.tsx,Button.test.tsx,Button.stories.tsx,index.ts}
+
+# Ejecutar tests
+npm run test -- Button.test.tsx
+
+# Ver coverage
+npm run test:coverage -- Button.test.tsx
+
+# Ejecutar Storybook
+npm run storybook
+
+# Build del componente
+npm run build
+```
+
+## 📊 Métricas de Calidad
+
+| Métrica           | Target                     |
+| ----------------- | -------------------------- |
+| Test Coverage     | >80%                       |
+| TypeScript Errors | 0                          |
+| ESLint Warnings   | 0                          |
+| Storybook Stories | ≥3 (variantes principales) |
+| ARIA Compliance   | 100%                       |
+
+## 📚 Ejemplo: TextInput
+
+````typescript
+// TextInput.tsx
+import { forwardRef, type InputHTMLAttributes } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const inputVariants = cva(
+  'w-full rounded-md border px-3 py-2 text-sm transition-colors',
+  {
+    variants: {
+      variant: {
+        default: 'border-gray-300 focus:border-primary-500',
+        error: 'border-red-500 focus:border-red-500',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+export interface TextInputProps
+  extends InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {
+  /** Mensaje de error */
+  error?: string;
+  /** Label del input */
+  label?: string;
+}
+
+/**
+ * Input de texto con soporte para errores y label
+ *
+ * @example
+ * ```tsx
+ * <TextInput
+ *   label="Email"
+ *   error="Email inválido"
+ *   value={email}
+ *   onChange={(e) => setEmail(e.target.value)}
+ * />
+ * ```
+ */
+export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+  ({ className, variant, error, label, ...props }, ref) => {
+    return (
+      <div className="flex flex-col gap-1">
+        {label && (
+          <label className="text-sm font-medium text-gray-700">
+            {label}
+          </label>
+        )}
+        <input
+          ref={ref}
+          className={cn(
+            inputVariants({ variant: error ? 'error' : variant }),
+            className
+          )}
+          aria-invalid={!!error}
+          aria-describedby={error ? 'error-message' : undefined}
+          {...props}
+        />
+        {error && (
+          <span id="error-message" className="text-sm text-red-600">
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+);
+
+TextInput.displayName = 'TextInput';
+````
+
+## 🔗 Skills Relacionadas
+
+- `test-generator` - Para generar tests automáticamente
+- `storybook-story-generator` - Para generar stories
+- `jsdoc-generator` - Para documentar props
+- `accessibility-checker` - Para validar a11y

--- a/.claude/skills/development/hook-builder.md
+++ b/.claude/skills/development/hook-builder.md
@@ -1,0 +1,460 @@
+# Hook Builder Skill
+
+## 📋 Descripción
+
+Construye custom hooks de React siguiendo best practices: TypeScript estricto, manejo de cleanup, tests exhaustivos, y documentación completa.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Crear hooks de utilidades (useDebounce, useLocalStorage)
+- Hooks de lógica de negocio (useSportsScores)
+- Hooks que encapsulan side effects
+- Abstraer lógica compartida entre componentes
+
+## 📁 Estructura de Archivos
+
+```
+src/hooks/
+├── useDebounce.ts       # Hook principal
+├── useDebounce.test.ts  # Tests unitarios
+└── index.ts             # Barrel export
+```
+
+## 🏗️ Template de Hook Utilitario
+
+````typescript
+// useDebounce.ts
+import { useState, useEffect } from 'react'
+
+/**
+ * Debounce de un valor que cambia frecuentemente
+ *
+ * @param value - Valor a hacer debounce
+ * @param delay - Tiempo de espera en ms (default: 500)
+ * @returns Valor con debounce aplicado
+ *
+ * @example
+ * ```tsx
+ * function SearchComponent() {
+ *   const [search, setSearch] = useState('');
+ *   const debouncedSearch = useDebounce(search, 300);
+ *
+ *   useEffect(() => {
+ *     // API call con debouncedSearch
+ *   }, [debouncedSearch]);
+ *
+ *   return <input value={search} onChange={(e) => setSearch(e.target.value)} />;
+ * }
+ * ```
+ */
+export function useDebounce<T>(value: T, delay: number = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    // Cleanup
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}
+````
+
+## 🏗️ Template de Hook con useQuery
+
+````typescript
+// useSportsScores.ts
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { sportsService } from '@/services/sports'
+import type { League, ScoresResponse } from '@/types'
+
+/**
+ * Obtiene scores de una liga específica
+ *
+ * @param league - Liga a consultar
+ * @param team - Filtro opcional por equipo
+ * @returns Query result con scores
+ *
+ * @example
+ * ```tsx
+ * function ScoresPage() {
+ *   const { data, isLoading, error } = useSportsScores('nba');
+ *
+ *   if (isLoading) return <Spinner />;
+ *   if (error) return <ErrorState />;
+ *
+ *   return <ScoreList scores={data} />;
+ * }
+ * ```
+ */
+export function useSportsScores(league: League, team?: string): UseQueryResult<ScoresResponse> {
+  return useQuery({
+    queryKey: ['sports', 'scores', league, team],
+    queryFn: () => sportsService.getScores(league, team),
+    staleTime: 30_000, // 30 segundos
+    gcTime: 5 * 60_000, // 5 minutos
+    refetchInterval: 30_000, // Refetch cada 30s para datos live
+    retry: 3,
+    enabled: !!league, // Solo ejecutar si hay liga
+  })
+}
+````
+
+## 🧪 Template de Tests
+
+```typescript
+// useDebounce.test.ts
+import { renderHook, waitFor } from '@testing-library/react'
+import { act } from 'react'
+import { useDebounce } from './useDebounce'
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('initial', 500))
+    expect(result.current).toBe('initial')
+  })
+
+  it('debounces value changes', async () => {
+    const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+      initialProps: { value: 'initial', delay: 500 },
+    })
+
+    // Cambiar valor
+    rerender({ value: 'updated', delay: 500 })
+
+    // Valor no debe cambiar inmediatamente
+    expect(result.current).toBe('initial')
+
+    // Avanzar tiempo
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    // Ahora debe estar actualizado
+    await waitFor(() => {
+      expect(result.current).toBe('updated')
+    })
+  })
+
+  it('cancels previous timeout on rapid changes', async () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 500), {
+      initialProps: { value: 'initial' },
+    })
+
+    // Múltiples cambios rápidos
+    rerender({ value: 'update1' })
+    act(() => vi.advanceTimersByTime(200))
+
+    rerender({ value: 'update2' })
+    act(() => vi.advanceTimersByTime(200))
+
+    rerender({ value: 'final' })
+    act(() => vi.advanceTimersByTime(500))
+
+    // Solo el último valor debe aplicarse
+    await waitFor(() => {
+      expect(result.current).toBe('final')
+    })
+  })
+
+  it('cleans up timeout on unmount', () => {
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+    const { unmount } = renderHook(() => useDebounce('value', 500))
+
+    unmount()
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+  })
+})
+```
+
+## 🧪 Template de Tests con React Query
+
+```typescript
+// useSportsScores.test.ts
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSportsScores } from './useSportsScores';
+import { sportsService } from '@/services/sports';
+
+// Mock del servicio
+vi.mock('@/services/sports', () => ({
+  sportsService: {
+    getScores: vi.fn(),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}
+
+describe('useSportsScores', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches scores successfully', async () => {
+    const mockScores = [
+      { homeTeam: 'Lakers', awayTeam: 'Warriors', homeScore: 110, awayScore: 105 },
+    ];
+
+    vi.mocked(sportsService.getScores).mockResolvedValue(mockScores);
+
+    const { result } = renderHook(() => useSportsScores('nba'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockScores);
+    expect(sportsService.getScores).toHaveBeenCalledWith('nba', undefined);
+  });
+
+  it('handles errors correctly', async () => {
+    const error = new Error('API Error');
+    vi.mocked(sportsService.getScores).mockRejectedValue(error);
+
+    const { result } = renderHook(() => useSportsScores('nba'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBe(error);
+  });
+
+  it('filters by team when provided', async () => {
+    vi.mocked(sportsService.getScores).mockResolvedValue([]);
+
+    renderHook(() => useSportsScores('nba', 'Lakers'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(sportsService.getScores).toHaveBeenCalledWith('nba', 'Lakers');
+    });
+  });
+
+  it('does not fetch when league is not provided', () => {
+    renderHook(() => useSportsScores('' as any), {
+      wrapper: createWrapper(),
+    });
+
+    expect(sportsService.getScores).not.toHaveBeenCalled();
+  });
+});
+```
+
+## ✅ Checklist de Implementación
+
+### Código
+
+- [ ] TypeScript sin errores
+- [ ] Tipos de retorno explícitos
+- [ ] JSDoc con ejemplo de uso
+- [ ] Parámetros con valores por defecto cuando aplique
+- [ ] Manejo de cleanup en `useEffect` si hay side effects
+- [ ] Memoización con `useMemo`/`useCallback` si es costoso
+
+### Naming
+
+- [ ] Nombre empieza con `use` (convención de React)
+- [ ] Nombre descriptivo (`useDebounce`, no `useDeb`)
+- [ ] Parámetros con nombres claros
+
+### Testing
+
+- [ ] Tests de comportamiento básico
+- [ ] Tests de edge cases
+- [ ] Tests de cleanup
+- [ ] Tests de dependencias (si usa otros hooks)
+- [ ] Coverage >90%
+
+### Documentación
+
+- [ ] JSDoc con descripción
+- [ ] JSDoc con `@param` para cada parámetro
+- [ ] JSDoc con `@returns`
+- [ ] JSDoc con `@example` con código funcional
+
+## 🔧 Comandos
+
+```bash
+# Crear estructura
+mkdir -p src/hooks
+touch src/hooks/{useDebounce.ts,useDebounce.test.ts}
+
+# Ejecutar tests
+npm run test -- useDebounce.test.ts
+
+# Ver coverage
+npm run test:coverage -- useDebounce.test.ts
+
+# Watch mode
+npm run test -- useDebounce.test.ts --watch
+```
+
+## 📊 Métricas de Calidad
+
+| Métrica               | Target |
+| --------------------- | ------ |
+| Test Coverage         | >90%   |
+| TypeScript Errors     | 0      |
+| Cyclomatic Complexity | <10    |
+| Max Parameters        | ≤4     |
+
+## 📚 Ejemplos de Hooks Comunes
+
+### useLocalStorage
+
+```typescript
+import { useState, useEffect } from 'react'
+
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T) => void, () => void] {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? JSON.parse(item) : initialValue
+    } catch (error) {
+      console.error(error)
+      return initialValue
+    }
+  })
+
+  const setValue = (value: T) => {
+    try {
+      setStoredValue(value)
+      window.localStorage.setItem(key, JSON.stringify(value))
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  const removeValue = () => {
+    try {
+      window.localStorage.removeItem(key)
+      setStoredValue(initialValue)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  return [storedValue, setValue, removeValue]
+}
+```
+
+### useMediaQuery
+
+```typescript
+import { useState, useEffect } from 'react'
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    const media = window.matchMedia(query)
+
+    if (media.matches !== matches) {
+      setMatches(media.matches)
+    }
+
+    const listener = () => setMatches(media.matches)
+    media.addEventListener('change', listener)
+
+    return () => media.removeEventListener('change', listener)
+  }, [matches, query])
+
+  return matches
+}
+```
+
+### useToggle
+
+```typescript
+import { useState, useCallback } from 'react'
+
+export function useToggle(
+  initialValue: boolean = false
+): [boolean, () => void, () => void, () => void] {
+  const [value, setValue] = useState(initialValue)
+
+  const toggle = useCallback(() => setValue((v) => !v), [])
+  const setTrue = useCallback(() => setValue(true), [])
+  const setFalse = useCallback(() => setValue(false), [])
+
+  return [value, toggle, setTrue, setFalse]
+}
+```
+
+## 🚨 Errores Comunes
+
+❌ **No limpiar side effects**
+
+```typescript
+useEffect(() => {
+  const timer = setTimeout(() => {...}, 1000);
+  // ❌ Falta cleanup
+}, []);
+```
+
+✅ **Correcto**
+
+```typescript
+useEffect(() => {
+  const timer = setTimeout(() => {...}, 1000);
+  return () => clearTimeout(timer); // ✅
+}, []);
+```
+
+❌ **Dependencias incorrectas**
+
+```typescript
+useEffect(() => {
+  fetchData(userId)
+}, []) // ❌ Falta userId
+```
+
+✅ **Correcto**
+
+```typescript
+useEffect(() => {
+  fetchData(userId)
+}, [userId]) // ✅
+```
+
+## 🔗 Skills Relacionadas
+
+- `test-generator` - Para generar tests de hooks
+- `jsdoc-generator` - Para documentar hooks
+- `service-builder` - Para hooks que usan servicios

--- a/.claude/skills/development/service-builder.md
+++ b/.claude/skills/development/service-builder.md
@@ -1,0 +1,156 @@
+# Service Builder Skill
+
+## 📋 Descripción
+
+Construye servicios con cliente HTTP, interceptores, error handling y transformers siguiendo los patrones del proyecto.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Crear capa de servicios
+- Integrar APIs externas
+- Implementar interceptores
+- Transformar datos de API
+
+## 📁 Estructura de Archivos
+
+```
+src/services/sports/
+├── sports.service.ts       # Funciones del servicio
+├── sports.types.ts         # Tipos TypeScript
+├── sports.transformers.ts  # Transformaciones
+├── sports.queries.ts       # React Query hooks
+└── index.ts                # Barrel export
+```
+
+## 🏗️ Template de Service
+
+```typescript
+// sports.service.ts
+import { apiClient } from '@/services/api/client'
+import type { League, ScoresResponse } from './sports.types'
+import { transformScores } from './sports.transformers'
+
+export const sportsService = {
+  /**
+   * Obtiene scores por liga
+   */
+  async getScores(league: League, team?: string): Promise<ScoresResponse> {
+    const response = await apiClient.get('/scores', {
+      params: { league, team },
+    })
+    return transformScores(response.data)
+  },
+
+  /**
+   * Obtiene standings por liga
+   */
+  async getStandings(league: League): Promise<StandingsResponse> {
+    const response = await apiClient.get('/standings', {
+      params: { league },
+    })
+    return response.data
+  },
+}
+```
+
+## 🔧 Interceptores
+
+```typescript
+// interceptors/request.interceptor.ts
+export const requestInterceptor = (config) => {
+  // Agregar headers comunes
+  config.headers['X-Request-ID'] = generateRequestId()
+
+  // Logging en desarrollo
+  if (import.meta.env.DEV) {
+    console.log(`[Request] ${config.method?.toUpperCase()} ${config.url}`)
+  }
+
+  return config
+}
+
+// interceptors/response.interceptor.ts
+export const responseInterceptor = (response) => {
+  // Extraer data automáticamente
+  return response.data
+}
+
+// interceptors/error.handler.ts
+export const errorHandler = (error) => {
+  if (error.response) {
+    switch (error.response.status) {
+      case 400:
+        toast.error('Request inválido')
+        break
+      case 401:
+        toast.error('No autorizado')
+        break
+      case 404:
+        toast.error('Recurso no encontrado')
+        break
+      case 500:
+        toast.error('Error del servidor')
+        break
+    }
+  } else if (error.request) {
+    toast.error('Error de red')
+  }
+
+  return Promise.reject(error)
+}
+```
+
+## 🔄 Transformers
+
+```typescript
+// sports.transformers.ts
+export const transformScores = (data: ApiScoreResponse[]): ScoresResponse => {
+  return data.map((score) => ({
+    id: score.game_id,
+    homeTeam: {
+      name: score.home_team,
+      logo: score.home_logo,
+      score: score.home_score,
+    },
+    awayTeam: {
+      name: score.away_team,
+      logo: score.away_logo,
+      score: score.away_score,
+    },
+    status: mapGameStatus(score.status),
+    date: new Date(score.date),
+  }))
+}
+```
+
+## 🪝 React Query Hooks
+
+```typescript
+// sports.queries.ts
+import { useQuery } from '@tanstack/react-query'
+import { sportsService } from './sports.service'
+
+export const useSportsScores = (league: League, team?: string) => {
+  return useQuery({
+    queryKey: ['sports', 'scores', league, team],
+    queryFn: () => sportsService.getScores(league, team),
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  })
+}
+```
+
+## ✅ Checklist de Implementación
+
+- [ ] Service con tipos TypeScript
+- [ ] Interceptores configurados
+- [ ] Error handler centralizado
+- [ ] Transformers para normalizar datos
+- [ ] React Query hooks
+- [ ] Tests con MSW mocking
+- [ ] JSDoc completo
+
+## 🔗 Skills Relacionadas
+
+- `hook-builder` - Para los React Query hooks
+- `test-generator` - Para tests del servicio

--- a/.claude/skills/documentation/architecture-documenter.md
+++ b/.claude/skills/documentation/architecture-documenter.md
@@ -1,0 +1,118 @@
+# Architecture Documenter Skill
+
+## 📋 Descripción
+
+Genera documentación de arquitectura y ADRs (Architecture Decision Records).
+
+## 🎯 Cuándo Usar
+
+- Después de decisiones arquitectónicas importantes
+- Al finalizar fases
+- Para documentar patrones
+
+## 📝 Template de ADR
+
+```markdown
+# ADR-001: Usar React Query para Server State
+
+## Estado
+
+Aceptado
+
+## Contexto
+
+Necesitamos manejar estado del servidor (API calls, caching, sincronización)
+de forma eficiente sin reimplementar soluciones existentes.
+
+## Decisión
+
+Usar TanStack Query (React Query) como solución de server state management.
+
+## Consecuencias
+
+### Positivas
+
+- Caching automático de requests
+- Invalidación inteligente
+- Retry y error handling built-in
+- DevTools para debugging
+- Reducción de boilerplate
+
+### Negativas
+
+- Curva de aprendizaje
+- Dependencia adicional
+- Overhead para queries muy simples
+
+## Alternativas Consideradas
+
+1. **Redux Toolkit + RTK Query**: Más pesado, mayor complejidad
+2. **SWR**: Similar pero menos features
+3. **Custom hooks con fetch**: Mucho código a mantener
+
+## Referencias
+
+- [TanStack Query Docs](https://tanstack.com/query)
+- Spike en branch `spike/react-query`
+```
+
+## 📊 Template de ARCHITECTURE.md
+
+```markdown
+# Arquitectura del Proyecto
+
+## 📐 Principios
+
+1. **Separation of Concerns**: Separación clara entre UI, lógica y datos
+2. **Composition over Inheritance**: Componentes pequeños y composables
+3. **Single Source of Truth**: Estado centralizado donde sea apropiado
+4. **Explicit Dependencies**: Dependencias explícitas vía props/hooks
+
+## 🏗️ Capas
+
+### Presentación (UI)
+
+- **Ubicación**: `src/components/`
+- **Responsabilidad**: Renderizado visual, interacciones de usuario
+- **Reglas**: No lógica de negocio, solo presentación
+
+### Lógica de Aplicación
+
+- **Ubicación**: `src/hooks/`
+- **Responsabilidad**: Lógica compartida, efectos, estado local
+- **Reglas**: Sin side effects globales, composables
+
+### Servicios (Data)
+
+- **Ubicación**: `src/services/`
+- **Responsabilidad**: Comunicación con APIs, transformación de datos
+- **Reglas**: Sin dependencias de UI, tipado estricto
+
+## 🔄 Flujo de Datos
+```
+
+User Action → Component → Hook → Service → API
+↑ │
+└──────────── Response ────────┘
+
+```
+
+## 📦 Patrón de Módulos
+
+Cada feature sigue este patrón:
+```
+
+feature/
+├── Component.tsx # Componente principal
+├── Component.test.tsx # Tests
+├── Component.stories.tsx # Storybook
+├── useFeature.ts # Lógica del feature
+└── index.ts # Exports públicos
+
+```
+
+```
+
+## 🔗 Skills Relacionadas
+
+- `project-orchestrator` - Usa ADRs para decisiones

--- a/.claude/skills/documentation/jsdoc-generator.md
+++ b/.claude/skills/documentation/jsdoc-generator.md
@@ -1,0 +1,105 @@
+# JSDoc Generator Skill
+
+## 📋 Descripción
+
+Genera documentación JSDoc completa para funciones, componentes y hooks.
+
+## 🎯 Cuándo Usar
+
+- Al crear funciones públicas
+- Para documentar APIs
+- Componentes y hooks
+
+## 📝 Templates
+
+### Componente
+
+````typescript
+/**
+ * Botón principal de la aplicación con múltiples variantes
+ *
+ * @example
+ * ```tsx
+ * <Button variant="primary" size="md" onClick={handleClick}>
+ *   Click me
+ * </Button>
+ * ```
+ *
+ * @example Con icono
+ * ```tsx
+ * <Button variant="primary" leftIcon={<Mail />}>
+ *   Send Email
+ * </Button>
+ * ```
+ */
+export interface ButtonProps {
+  /** Variante visual del botón */
+  variant?: 'primary' | 'secondary' | 'outline'
+  /** Tamaño del botón */
+  size?: 'sm' | 'md' | 'lg'
+  /** Muestra un spinner y deshabilita el botón */
+  loading?: boolean
+  /** Icono a la izquierda del texto */
+  leftIcon?: React.ReactNode
+  /** Click handler */
+  onClick?: () => void
+}
+````
+
+### Hook
+
+````typescript
+/**
+ * Debounce de un valor que cambia frecuentemente
+ *
+ * @param value - Valor a hacer debounce
+ * @param delay - Tiempo de espera en ms (default: 500)
+ * @returns Valor con debounce aplicado
+ *
+ * @example
+ * ```tsx
+ * function SearchComponent() {
+ *   const [search, setSearch] = useState('');
+ *   const debouncedSearch = useDebounce(search, 300);
+ *
+ *   useEffect(() => {
+ *     // API call con debouncedSearch
+ *   }, [debouncedSearch]);
+ *
+ *   return <input value={search} onChange={(e) => setSearch(e.target.value)} />;
+ * }
+ * ```
+ */
+export function useDebounce<T>(value: T, delay: number = 500): T
+````
+
+### Función
+
+````typescript
+/**
+ * Combina clases CSS usando clsx y tailwind-merge
+ *
+ * @param inputs - Clases a combinar
+ * @returns String de clases combinadas sin duplicados
+ *
+ * @example
+ * ```ts
+ * cn('px-2 py-1', 'px-4') // => 'py-1 px-4'
+ * cn('text-red-500', { 'text-blue-500': isActive }) // => 'text-blue-500'
+ * ```
+ */
+export function cn(...inputs: ClassValue[]): string
+````
+
+## ✅ Elementos Requeridos
+
+- [ ] Descripción breve y clara
+- [ ] `@param` para cada parámetro
+- [ ] `@returns` para valor de retorno
+- [ ] `@example` con código funcional
+- [ ] Tipos TypeScript correctos
+
+## 🔗 Skills Relacionadas
+
+- `component-builder` - Genera JSDoc automáticamente
+- `hook-builder` - Documenta hooks

--- a/.claude/skills/documentation/storybook-story-generator.md
+++ b/.claude/skills/documentation/storybook-story-generator.md
@@ -1,0 +1,92 @@
+# Storybook Story Generator Skill
+
+## 📋 Descripción
+
+Genera Storybook stories con todas las variantes de un componente, controles interactivos y documentación autodocs.
+
+## 🎯 Cuándo Usar
+
+- Después de crear un componente
+- Para documentar variantes
+- Testing visual
+
+## 📝 Template de Story
+
+```typescript
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'UI/Buttons/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'Componente Button con múltiples variantes y tamaños.'
+      }
+    }
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'outline'],
+      description: 'Variante visual del botón'
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Tamaño del botón'
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Variantes individuales
+export const Primary: Story = {
+  args: { children: 'Primary Button', variant: 'primary' }
+};
+
+export const Secondary: Story = {
+  args: { children: 'Secondary Button', variant: 'secondary' }
+};
+
+// Showcases
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <Button variant="primary">Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="outline">Outline</Button>
+    </div>
+  )
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  )
+};
+```
+
+## 📊 Stories Requeridas
+
+Para cada componente:
+
+- ✅ Story por cada variante principal
+- ✅ AllVariants showcase
+- ✅ AllSizes showcase (si aplica)
+- ✅ AllStates showcase (loading, disabled, error)
+- ✅ Playground con controles interactivos
+
+## 🔗 Skills Relacionadas
+
+- `component-builder` - Genera stories automáticamente
+- `jsdoc-generator` - Documentación en stories

--- a/.claude/skills/github/conventional-commits.md
+++ b/.claude/skills/github/conventional-commits.md
@@ -1,0 +1,342 @@
+# Conventional Commits Skill
+
+## 📋 Descripción
+
+Genera commits siguiendo la especificación de Conventional Commits, garantizando consistencia en el historial de Git y facilitando la generación automática de changelogs.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Cada commit en el proyecto
+- Antes de hacer push
+- Al completar una funcionalidad o fix
+- Para mantener historial limpio y semántico
+
+## 📝 Formato Obligatorio
+
+```
+<type>(<scope>): <descripción>
+
+[cuerpo opcional con más detalles]
+
+[footer opcional con referencias]
+
+Refs #ISSUE_NUMBER
+```
+
+## 🏷️ Types Permitidos
+
+| Type       | Uso                         | Ejemplo                                 |
+| ---------- | --------------------------- | --------------------------------------- |
+| `feat`     | Nueva funcionalidad         | `feat(ui): add Button component`        |
+| `fix`      | Corrección de bug           | `fix(api): handle timeout errors`       |
+| `docs`     | Documentación               | `docs(readme): add setup instructions`  |
+| `style`    | Formateo (no afecta lógica) | `style: format with prettier`           |
+| `refactor` | Refactoring                 | `refactor(hooks): simplify useDebounce` |
+| `test`     | Tests                       | `test(ui): add Card tests`              |
+| `chore`    | Mantenimiento               | `chore(deps): update dependencies`      |
+| `perf`     | Performance                 | `perf(api): add request caching`        |
+| `ci`       | CI/CD                       | `ci: add e2e workflow`                  |
+| `build`    | Build system                | `build: optimize bundle size`           |
+| `revert`   | Revert de commit            | `revert: feat(ui): add Button`          |
+
+## 🎯 Scopes Permitidos
+
+| Scope    | Uso              |
+| -------- | ---------------- |
+| `ui`     | Componentes UI   |
+| `hooks`  | Custom hooks     |
+| `api`    | Servicios/API    |
+| `config` | Configuración    |
+| `deps`   | Dependencias     |
+| `types`  | TypeScript types |
+| `test`   | Testing          |
+| `docs`   | Documentación    |
+| `router` | Routing          |
+| `store`  | Estado global    |
+| `styles` | Estilos globales |
+
+## ✍️ Reglas de Escritura
+
+### Descripción (Subject)
+
+- **Máximo 72 caracteres**
+- Usar imperativo ("add" no "added" ni "adds")
+- No capitalizar primera letra
+- No punto final
+- Ser específico y conciso
+
+✅ **Buenos ejemplos:**
+
+- `feat(ui): add Button component with variants`
+- `fix(api): handle network timeout errors`
+- `test(hooks): add useDebounce unit tests`
+
+❌ **Malos ejemplos:**
+
+- `feat: stuff` (muy vago)
+- `Fix button.` (capitalizado, punto final)
+- `Added new button component with primary and secondary variants and loading state` (muy largo)
+
+### Cuerpo (Body)
+
+- **Opcional pero recomendado para cambios complejos**
+- Separar del subject con línea en blanco
+- Wrap a 72 caracteres
+- Explicar **qué** y **por qué**, no **cómo**
+- Usar viñetas para múltiples cambios
+
+✅ **Buen ejemplo:**
+
+```
+feat(ui): add Button component
+
+- Implement all variants (primary, secondary, outline)
+- Add loading state with spinner
+- Include forwardRef for form integration
+- Support for left/right icons
+```
+
+### Footer
+
+- **Obligatorio para referencias a issues**
+- Formato: `Refs #ISSUE_NUMBER`
+- Breaking changes: `BREAKING CHANGE: descripción`
+- Múltiples issues: `Refs #15, #16`
+
+## 📚 Ejemplos Completos
+
+### Feature Simple
+
+```bash
+git commit -m "feat(ui): add TextInput component
+
+Refs #11"
+```
+
+### Feature Compleja
+
+```bash
+git commit -m "feat(ui): add ScoreCard component
+
+- Display team logos and names
+- Show live score updates
+- Support different game statuses (live, finished, upcoming)
+- Add hover animations
+- Include favorite team indicator
+
+Refs #23"
+```
+
+### Bugfix
+
+```bash
+git commit -m "fix(api): handle timeout in sports service
+
+Network requests were failing silently after 10s. Now properly
+handle timeouts and show error toast to user.
+
+Refs #45"
+```
+
+### Tests
+
+```bash
+git commit -m "test(ui): add Button unit tests
+
+- Test all variants render correctly
+- Test onClick handler fires
+- Test disabled state blocks interaction
+- Test keyboard navigation
+- Coverage: 94%
+
+Refs #15"
+```
+
+### Documentación
+
+```bash
+git commit -m "docs(ui): add Button Storybook stories
+
+- Add stories for all variants
+- Add interactive controls
+- Document all props with descriptions
+- Add usage examples
+
+Refs #15"
+```
+
+### Refactoring
+
+```bash
+git commit -m "refactor(hooks): simplify useDebounce implementation
+
+Replace multiple useState calls with single useRef.
+Reduces re-renders and improves performance.
+
+Refs #67"
+```
+
+### Breaking Change
+
+```bash
+git commit -m "feat(api): change response format
+
+BREAKING CHANGE: API responses now return data in camelCase
+instead of snake_case. Update all transformers accordingly.
+
+Refs #89"
+```
+
+### Multiple Issues
+
+```bash
+git commit -m "fix(ui): resolve styling inconsistencies
+
+- Fix Button padding in Safari
+- Align Card shadows across browsers
+- Standardize input border radius
+
+Refs #34, #35, #36"
+```
+
+## 🔧 Comandos Git
+
+```bash
+# Commit simple
+git add .
+git commit -m "feat(ui): add Button component
+
+Refs #15"
+
+# Commit con cuerpo
+git add .
+git commit -m "feat(ui): add Button component
+
+- Implement all variants
+- Add loading state
+- Include accessibility features
+
+Refs #15"
+
+# Amend (corregir último commit)
+git commit --amend -m "feat(ui): add Button component with variants
+
+Refs #15"
+
+# Ver historial con formato
+git log --oneline --graph --all
+```
+
+## ✅ Validación con Commitlint
+
+**Configuración (`commitlint.config.js`):**
+
+```javascript
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'style',
+        'refactor',
+        'test',
+        'chore',
+        'perf',
+        'ci',
+        'build',
+        'revert',
+      ],
+    ],
+    'scope-enum': [
+      2,
+      'always',
+      [
+        'ui',
+        'hooks',
+        'api',
+        'config',
+        'deps',
+        'types',
+        'test',
+        'docs',
+        'router',
+        'store',
+        'styles',
+      ],
+    ],
+    'subject-case': [2, 'always', 'lower-case'],
+    'subject-max-length': [2, 'always', 72],
+    'subject-full-stop': [2, 'never', '.'],
+    'body-leading-blank': [2, 'always'],
+    'footer-leading-blank': [2, 'always'],
+  },
+}
+```
+
+## 🚨 Errores Comunes y Soluciones
+
+### ❌ Error 1: Subject muy largo
+
+```bash
+# ❌ Incorrecto (>72 caracteres)
+git commit -m "feat(ui): add new button component with multiple variants including primary secondary outline and ghost with loading states"
+
+# ✅ Correcto
+git commit -m "feat(ui): add Button component with variants
+
+- primary, secondary, outline, ghost
+- loading states supported
+
+Refs #15"
+```
+
+### ❌ Error 2: Type inválido
+
+```bash
+# ❌ Incorrecto
+git commit -m "update(ui): modify Button"
+
+# ✅ Correcto
+git commit -m "refactor(ui): modify Button structure"
+```
+
+### ❌ Error 3: Subject capitalizado
+
+```bash
+# ❌ Incorrecto
+git commit -m "feat(ui): Add Button component"
+
+# ✅ Correcto
+git commit -m "feat(ui): add Button component"
+```
+
+### ❌ Error 4: Sin referencia a issue
+
+```bash
+# ❌ Incorrecto
+git commit -m "feat(ui): add Button component"
+
+# ✅ Correcto
+git commit -m "feat(ui): add Button component
+
+Refs #15"
+```
+
+## 📊 Beneficios
+
+1. **Historial Semántico**: Fácil de entender qué cambió
+2. **Changelog Automático**: Herramientas pueden generar CHANGELOG.md
+3. **Versionado Semántico**: Determinar major/minor/patch automáticamente
+4. **Navegación Rápida**: Buscar commits por tipo o scope
+5. **CI/CD**: Triggers automáticos basados en tipos
+
+## 🔗 Skills Relacionadas
+
+- `github-flow-executor` - Usa conventional commits en el flujo
+- `pr-creator` - Title del PR sigue mismo formato
+- `changelog-generator` - Genera changelog desde commits

--- a/.claude/skills/github/github-flow-executor.md
+++ b/.claude/skills/github/github-flow-executor.md
@@ -1,0 +1,295 @@
+# GitHub Flow Executor Skill
+
+## 📋 Descripción
+
+Ejecuta el flujo completo de desarrollo en GitHub: crear issue → crear rama → commits → PR → review → merge, siguiendo las convenciones del proyecto.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Cada tarea de desarrollo (componente, hook, service, test)
+- Cuando necesitas seguir el flujo estándar del proyecto
+- Para garantizar consistencia en el proceso de desarrollo
+
+## 🔄 Flujo Completo
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1️⃣  CREAR ISSUE                                             │
+│ gh issue create --template task.yml                        │
+└─────────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2️⃣  CREAR RAMA                                              │
+│ git checkout develop && git pull                           │
+│ git checkout -b feature/TASK-XXX-nombre                    │
+└─────────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3️⃣  IMPLEMENTAR                                             │
+│ - Código siguiendo estándares                              │
+│ - Tests con coverage >80%                                  │
+│ - Storybook story (si es componente)                       │
+└─────────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 4️⃣  COMMITS (Conventional Commits)                          │
+│ git add .                                                  │
+│ git commit -m "type(scope): descripción\n\nRefs #XX"       │
+└─────────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 5️⃣  PUSH Y CREAR PR                                         │
+│ git push -u origin feature/TASK-XXX-nombre                 │
+│ gh pr create --template pull_request_template.md           │
+└─────────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 6️⃣  VERIFICAR CI                                            │
+│ gh pr checks                                               │
+│ (Esperar a que pasen los tests)                            │
+└─────────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 7️⃣  REVIEW & MERGE                                          │
+│ gh pr review --approve                                     │
+│ gh pr merge --squash --delete-branch                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 🔧 Paso 1: Crear Issue
+
+**Usar template existente:**
+
+```bash
+gh issue create \
+  --title "[TASK-XXX] Nombre descriptivo de la tarea" \
+  --body-file .github/ISSUE_TEMPLATE/task.yml \
+  --label "type: task" \
+  --label "phase: X-nombre-fase" \
+  --label "priority: medium" \
+  --label "agent: component"
+```
+
+**Campos obligatorios del template:**
+
+- **Descripción**: Qué se debe implementar
+- **Criterios de Aceptación**: Lista de checks
+- **Dependencias**: Issues relacionados
+- **Estimación**: Tiempo esperado
+- **Agente Asignado**: Qué agente lo ejecutará
+- **Tecnologías**: Stack involucrado
+
+## 🔧 Paso 2: Crear Rama
+
+**Convención de nombres:**
+
+```bash
+# Features
+feature/TASK-XXX-nombre-descriptivo
+
+# Bugfixes
+fix/TASK-XXX-nombre-descriptivo
+
+# Documentación
+docs/TASK-XXX-nombre-descriptivo
+
+# Tests
+test/TASK-XXX-nombre-descriptivo
+
+# Refactoring
+refactor/TASK-XXX-nombre-descriptivo
+```
+
+**Comandos:**
+
+```bash
+# Asegurarse de estar en develop actualizado
+git checkout develop
+git pull origin develop
+
+# Crear rama
+git checkout -b feature/TASK-001-setup-vite
+```
+
+## 🔧 Paso 3: Implementar
+
+**Checklist de implementación:**
+
+- [ ] Código sigue estándares del proyecto
+- [ ] TypeScript sin errores (`tsc --noEmit`)
+- [ ] ESLint sin warnings (`npm run lint`)
+- [ ] Prettier formateado (`npm run format`)
+- [ ] Tests escritos (coverage >80%)
+- [ ] Storybook story (si es componente)
+- [ ] JSDoc completo
+
+## 🔧 Paso 4: Commits
+
+**Usar skill `conventional-commits`**
+
+**Formato obligatorio:**
+
+```
+<type>(<scope>): <descripción>
+
+[cuerpo opcional con más detalles]
+
+Refs #ISSUE_NUMBER
+```
+
+**Types permitidos:**
+
+- `feat` - Nueva funcionalidad
+- `fix` - Corrección de bug
+- `docs` - Documentación
+- `test` - Tests
+- `refactor` - Refactoring
+- `style` - Formateo
+- `chore` - Mantenimiento
+- `perf` - Performance
+- `ci` - CI/CD
+
+**Scopes permitidos:**
+
+- `ui`, `hooks`, `api`, `config`, `types`, `test`, `docs`, `router`, `store`
+
+**Ejemplo:**
+
+```bash
+git add .
+git commit -m "feat(ui): add TextInput component
+
+- Implement all variants (default, error, disabled, with-icon)
+- Add forwardRef support for form integration
+- Include ARIA attributes for accessibility
+
+Refs #15"
+```
+
+## 🔧 Paso 5: Push y Crear PR
+
+**Usar template existente:**
+
+```bash
+# Push
+git push -u origin feature/TASK-001-setup-vite
+
+# Crear PR usando template
+gh pr create \
+  --base develop \
+  --title "feat(ui): Add TextInput component" \
+  --body-file .github/pull_request_template.md \
+  --label "type: feature" \
+  --label "phase: 1-design-system"
+```
+
+**Campos obligatorios del template:**
+
+- **Descripción**: Qué cambios se hicieron
+- **Issue Relacionado**: `Closes #XX`
+- **Tipo de Cambio**: Feature/Fix/Docs/etc
+- **Checklist**: Código, Testing, Documentación
+- **Cómo Probar**: Instrucciones para revisar
+
+## 🔧 Paso 6: Verificar CI
+
+**Monitorear checks:**
+
+```bash
+# Ver estado del PR actual
+gh pr status
+
+# Ver checks en detalle
+gh pr checks
+
+# Ver logs si falla
+gh run view --log
+
+# Si hay errores, corregir y push
+git add .
+git commit -m "fix(ui): address PR feedback"
+git push
+```
+
+**CI debe pasar:**
+
+- ✅ TypeScript build (`npm run build`)
+- ✅ Linter (`npm run lint`)
+- ✅ Tests (`npm run test:run`)
+- ✅ Coverage >80%
+
+## 🔧 Paso 7: Review & Merge
+
+**Aprobar PR:**
+
+```bash
+gh pr review --approve --body "LGTM! ✅ Tests passing, code looks good."
+```
+
+**Merge con squash:**
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+**Resultado:**
+
+- Commits squashed en uno solo
+- Rama feature eliminada
+- Issue cerrado automáticamente (por "Closes #XX")
+- Develop actualizado
+
+## ✅ Criterios de Éxito
+
+- [ ] Issue creado con template correcto
+- [ ] Rama sigue convención de nombres
+- [ ] Commits siguen Conventional Commits
+- [ ] PR incluye referencia al issue (`Closes #XX`)
+- [ ] CI pasa completamente
+- [ ] Review aprobado
+- [ ] Merge exitoso sin conflictos
+
+## 📚 Ejemplo Completo
+
+```bash
+# PASO 1: Crear issue
+gh issue create \
+  --title "[TASK-011] Crear componente TextInput" \
+  --body "..." \
+  --label "type: task,phase: 1-design-system,agent: component"
+
+# PASO 2: Crear rama
+git checkout develop && git pull
+git checkout -b feature/TASK-011-text-input
+
+# PASO 3: Implementar
+# (Escribir código, tests, story)
+
+# PASO 4: Commit
+git add .
+git commit -m "feat(ui): add TextInput component\n\nRefs #11"
+
+# PASO 5: Push y PR
+git push -u origin feature/TASK-011-text-input
+gh pr create --base develop --title "feat(ui): Add TextInput component"
+
+# PASO 6: Verificar CI
+gh pr checks
+
+# PASO 7: Merge
+gh pr review --approve
+gh pr merge --squash --delete-branch
+```
+
+## 🔗 Skills Relacionadas
+
+- `conventional-commits` - Para formatear commits
+- `pr-creator` - Para crear PRs desde templates
+- `issue-creator` - Para crear issues desde templates
+- `code-reviewer` - Para validar antes de aprobar

--- a/.claude/skills/github/issue-creator.md
+++ b/.claude/skills/github/issue-creator.md
@@ -1,0 +1,87 @@
+# Issue Creator Skill
+
+## 📋 Descripción
+
+Crea issues en GitHub desde templates con criterios de aceptación, dependencias y estimaciones.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Al planificar tareas del backlog
+- Parte del flujo de task-planner
+- Para descomponer épicas
+
+## 📝 Template de Issue
+
+```yaml
+name: 📋 Task
+description: Tarea de desarrollo
+title: '[TASK-XXX] '
+labels: ['type: task']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Descripción
+        [Descripción detallada de qué se debe implementar]
+
+  - type: checkboxes
+    id: acceptance-criteria
+    attributes:
+      label: ✅ Criterios de Aceptación
+      options:
+        - label: Criterio 1
+        - label: Criterio 2
+        - label: Tests unitarios con coverage >80%
+        - label: Documentación JSDoc completa
+
+  - type: input
+    id: dependencies
+    attributes:
+      label: 🔗 Dependencias
+      placeholder: 'Depende de: #XX, Bloquea a: #YY'
+
+  - type: input
+    id: estimation
+    attributes:
+      label: ⏱️ Estimación
+      placeholder: 'X horas'
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: 🤖 Agente Asignado
+      options:
+        - Component Agent
+        - Hook Agent
+        - Service Agent
+        - Testing Agent
+        - Docs Agent
+
+  - type: textarea
+    id: technologies
+    attributes:
+      label: 🛠️ Tecnologías Involucradas
+      placeholder: |
+        - React, TypeScript, Tailwind CSS
+        - Vitest, React Testing Library
+```
+
+## 🔧 Comandos
+
+```bash
+# Crear issue con template
+gh issue create \
+  --title "[TASK-011] Crear componente TextInput" \
+  --body "..." \
+  --label "type: task,phase: 1-design-system,priority: high,agent: component"
+
+# Crear múltiples issues desde archivo
+for task in $(cat tasks.yml); do
+  gh issue create --body "$task"
+done
+```
+
+## 🔗 Skills Relacionadas
+
+- `task-planner` - Genera el plan de issues
+- `github-flow-executor` - Usa los issues creados

--- a/.claude/skills/github/pr-creator.md
+++ b/.claude/skills/github/pr-creator.md
@@ -1,0 +1,83 @@
+# PR Creator Skill
+
+## 📋 Descripción
+
+Crea Pull Requests desde templates con contexto automático, checklist completa y referencias a issues.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Al completar una tarea y hacer push
+- Parte del flujo github-flow-executor
+- Para PRs automatizados desde CI
+
+## 📝 Template de PR
+
+```markdown
+## 📋 Descripción
+
+[Descripción clara de los cambios realizados]
+
+## 🔗 Issue Relacionado
+
+Closes #[ISSUE_NUMBER]
+
+## 📝 Tipo de Cambio
+
+- [ ] 🆕 Nueva funcionalidad (feature)
+- [ ] 🐛 Corrección de bug (fix)
+- [ ] 📚 Documentación (docs)
+- [ ] ♻️ Refactoring
+- [ ] 🧪 Tests
+- [ ] 🎨 Estilos
+
+## ✅ Checklist
+
+### Código
+
+- [ ] Sigue los estándares del proyecto
+- [ ] Self-review realizado
+- [ ] Sin warnings de TypeScript/ESLint
+- [ ] Código formateado con Prettier
+
+### Testing
+
+- [ ] Tests unitarios añadidos
+- [ ] Coverage >80% (actual: XX%)
+- [ ] Todos los tests pasan
+
+### Documentación
+
+- [ ] JSDoc completo
+- [ ] Storybook story creada (si es componente)
+- [ ] README actualizado (si aplica)
+
+## 🧪 Cómo Probar
+
+1. [Paso 1]
+2. [Paso 2]
+3. [Paso 3]
+
+## 📸 Screenshots (si aplica)
+
+[Capturas de pantalla]
+```
+
+## 🔧 Comandos
+
+```bash
+# Crear PR con template
+gh pr create \
+  --base develop \
+  --title "feat(ui): add Button component" \
+  --body-file .github/pull_request_template.md \
+  --label "type: feature" \
+  --label "phase: 1-design-system"
+
+# Crear PR con generación automática
+gh pr create --fill
+```
+
+## 🔗 Skills Relacionadas
+
+- `github-flow-executor` - Usa este skill
+- `conventional-commits` - Para el título del PR

--- a/.claude/skills/orchestration/milestone-tracker.md
+++ b/.claude/skills/orchestration/milestone-tracker.md
@@ -1,0 +1,223 @@
+# Milestone Tracker Skill
+
+## 📋 Descripción
+
+Rastrea progreso de fases, detecta bloqueos, genera reportes y mantiene métricas del proyecto actualizadas.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Durante la ejecución del proyecto
+- Para reportes de progreso
+- Detectar tareas atrasadas o bloqueadas
+- Sprint reviews y retrospectivas
+
+## 📊 Métricas Rastreadas
+
+### Por Fase
+
+- Tareas completadas vs pendientes
+- Tiempo real vs estimado
+- Coverage promedio
+- Test pass rate
+- Issues bloqueantes
+
+### Globales
+
+- Velocidad (tareas/día)
+- Burndown chart
+- Coverage total del proyecto
+- Deuda técnica
+
+## 🔄 Flujo de Tracking
+
+```
+1. RECOLECTAR DATOS
+   ├─ Estado de issues (open/closed)
+   ├─ Estado de PRs
+   ├─ Resultados de CI
+   ├─ Coverage reports
+   └─ Tiempo por tarea
+
+2. CALCULAR MÉTRICAS
+   ├─ % completado por fase
+   ├─ Velocidad actual
+   ├─ ETA (estimated time of arrival)
+   ├─ Trend de coverage
+   └─ Blocker count
+
+3. DETECTAR ANOMALÍAS
+   ├─ Tareas estancadas >48h
+   ├─ Coverage bajando
+   ├─ CI frecuentemente fallando
+   └─ Dependencias bloqueadas
+
+4. GENERAR REPORTE
+   ├─ Dashboard de progreso
+   ├─ Alertas de bloqueos
+   ├─ Recomendaciones
+   └─ Próximos pasos
+```
+
+## 📈 Template de Reporte
+
+```markdown
+# 📊 Reporte de Progreso - [Fecha]
+
+## 🎯 Resumen Ejecutivo
+
+- **Fase Actual:** [Nombre de fase]
+- **Progreso Global:** XX% (YY/ZZ tareas)
+- **Estado:** En tiempo | Atrasado | Adelantado
+- **ETA:** [Fecha estimada de finalización]
+
+## 📉 Métricas por Fase
+
+### FASE 0: Setup y Configuración
+
+- ✅ Completada: 10/10 tareas (100%)
+- ⏱️ Tiempo: 7.2h (vs 8h estimadas)
+- ✅ Coverage: N/A
+- ✅ CI: Pasando
+
+### FASE 1: Design System
+
+- 🔄 En progreso: 18/28 tareas (64%)
+- ⏱️ Tiempo: 15h de 28h estimadas
+- 📊 Coverage: 87%
+- ✅ CI: Pasando
+- ⚠️ Bloqueadores: 2
+
+#### Tareas Bloqueadas
+
+- TASK-025 (TeamCard): Esperando TASK-019 (Card base)
+- TASK-026 (LeagueCard): Esperando TASK-019 (Card base)
+
+### FASE 2: Hooks y Utilidades
+
+- ⏸️ No iniciada: 0/15 tareas (0%)
+- ⏱️ Estimado: 14h
+
+## 📊 Métricas Globales
+
+| Métrica         | Actual         | Target         | Estado |
+| --------------- | -------------- | -------------- | ------ |
+| Coverage        | 87%            | >80%           | ✅     |
+| Test Pass Rate  | 100%           | 100%           | ✅     |
+| Velocidad       | 3.2 tareas/día | 3.5 tareas/día | ⚠️     |
+| CI Success Rate | 95%            | >90%           | ✅     |
+| Issues Abiertos | 12             | -              | -      |
+| PRs Pendientes  | 2              | -              | -      |
+
+## 🔥 Alertas
+
+### 🚨 Críticas
+
+- Ninguna
+
+### ⚠️ Advertencias
+
+- Velocidad 8% por debajo del target
+- 2 tareas bloqueadas en FASE 1
+
+### 💡 Recomendaciones
+
+1. Priorizar TASK-019 para desbloquear TASK-025 y TASK-026
+2. Revisar estimaciones de FASE 1 (muy optimistas)
+3. Considerar paralelizar tareas de FASE 2 mientras se completa FASE 1
+
+## 📅 Próximos Hitos
+
+- [ ] FASE 1 completada: 3 días (estimado)
+- [ ] FASE 2 iniciada: 4 días
+- [ ] FASE 2 completada: 8 días
+- [ ] Merge a main: 10 días
+
+## 📈 Burndown Chart
+```
+
+Tareas Restantes
+│
+70│ ╱
+│ ╱
+50│╱
+│ ╲
+30│ ╲***
+│ ╲***
+10│ ╲***Actual
+│ ╲***
+0 └─────────────────────────► Días
+0 2 4 6 8 10 12 14
+│
+Hoy
+
+```
+
+## 🎯 Conclusión
+El proyecto está progresando bien con un ligero retraso respecto al plan original.
+Se recomienda priorizar tareas bloqueantes para mantener el flujo.
+```
+
+## 🔧 Comandos
+
+```bash
+# Generar reporte de progreso
+gh run list --json conclusion,name | jq '.[] | select(.name=="CI")'
+
+# Ver issues por estado
+gh issue list --json state,title,labels | jq 'group_by(.state)'
+
+# Calcular velocidad
+gh issue list --state closed --json closedAt | jq 'length'
+
+# Detectar tareas estancadas
+gh issue list --json updatedAt,title | jq '.[] | select(.updatedAt < "2024-03-24")'
+```
+
+## 📊 Dashboard en GitHub
+
+```markdown
+<!-- Crear archivo PROGRESS.md en el repo -->
+
+# 📊 Sports Dashboard - Progress Dashboard
+
+**Última actualización:** [Fecha]
+
+## 🎯 Progreso Global
+
+![Progress](https://progress-bar.dev/64/?title=Completado&width=400)
+
+## 📈 Por Fase
+
+| Fase             | Tareas | Completadas | %    | Estado |
+| ---------------- | ------ | ----------- | ---- | ------ |
+| 0: Setup         | 10     | 10          | 100% | ✅     |
+| 1: Design System | 28     | 18          | 64%  | 🔄     |
+| 2: Hooks         | 15     | 0           | 0%   | ⏸️     |
+| 3: Services      | 12     | 0           | 0%   | ⏸️     |
+| 4: Features      | 22     | 0           | 0%   | ⏸️     |
+| 5: Testing E2E   | 8      | 0           | 0%   | ⏸️     |
+| 6: Docs          | 7      | 0           | 0%   | ⏸️     |
+
+## 🔥 Issues Críticos
+
+- TASK-019 bloqueando 2 tareas
+
+## 📊 Métricas de Calidad
+
+- **Coverage:** 87% ✅
+- **Tests Passing:** 100% ✅
+- **CI Success:** 95% ✅
+```
+
+## ✅ Checklist de Tracking
+
+- [ ] Métricas actualizadas diariamente
+- [ ] Bloqueadores identificados
+- [ ] Reportes generados semanalmente
+- [ ] Dashboard visible en README
+- [ ] Alertas configuradas para anomalías
+
+## 🔗 Skills Relacionadas
+
+- `project-orchestrator` - Usa tracking para ajustar plan
+- `task-planner` - Estimaciones iniciales

--- a/.claude/skills/orchestration/project-orchestrator.md
+++ b/.claude/skills/orchestration/project-orchestrator.md
@@ -1,0 +1,120 @@
+# Project Orchestrator Skill
+
+## 📋 Descripción
+
+Coordina la ejecución de proyectos complejos usando un enfoque multi-agente, asignando tareas especializadas a agentes específicos y monitoreando el progreso global.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Proyectos con >50 tareas interdependientes
+- Desarrollo de aplicaciones completas desde cero
+- Cuando hay múltiples fases secuenciales
+- Necesitas coordinar diferentes especialidades (frontend, testing, docs)
+
+## 🤖 Agentes Especializados
+
+| Agente        | Responsabilidad                 | Entregables                   |
+| ------------- | ------------------------------- | ----------------------------- |
+| **Architect** | Decisiones técnicas, estructura | Diagramas, ADRs, configs      |
+| **Setup**     | Tooling, CI/CD                  | Configs, workflows            |
+| **Component** | Componentes UI                  | Componentes + tests + stories |
+| **Hook**      | Custom hooks                    | Hooks + tests                 |
+| **Service**   | API, servicios                  | Services + interceptores      |
+| **Testing**   | Tests unitarios/E2E             | Test suites, coverage         |
+| **Docs**      | Documentación                   | MD files, Storybook docs      |
+| **Review**    | Code review                     | Feedback, approvals           |
+
+## 📊 Flujo de Ejecución
+
+```
+1. ANALIZAR PLAN
+   ├─ Leer documento maestro completo
+   ├─ Identificar fases y dependencias
+   └─ Crear grafo de dependencias
+
+2. PRIORIZAR TAREAS
+   ├─ Ordenar por dependencias (topological sort)
+   ├─ Identificar tareas bloqueantes
+   └─ Marcar tareas que pueden ejecutarse en paralelo
+
+3. EJECUTAR FASE
+   ├─ Para cada tarea en la fase:
+   │  ├─ Verificar dependencias completadas
+   │  ├─ Asignar agente especializado
+   │  ├─ Ejecutar tarea (issue → branch → code → test → PR → merge)
+   │  └─ Verificar criterios de aceptación
+   └─ Al completar fase: merge develop → main
+
+4. MONITOREAR PROGRESO
+   ├─ Rastrear tareas completadas/pendientes/bloqueadas
+   ├─ Reportar métricas (tiempo, cobertura, issues)
+   └─ Identificar desviaciones del plan
+
+5. DOCUMENTAR DECISIONES
+   ├─ Registrar cambios arquitectónicos
+   ├─ Actualizar ADRs (Architecture Decision Records)
+   └─ Generar changelog
+```
+
+## 🔧 Comandos Principales
+
+```bash
+# Verificar estado del proyecto
+gh issue list --label "phase: X-nombre-fase" --state open
+
+# Ver dependencias de una tarea
+gh issue view TASK-XXX
+
+# Verificar progreso de fase
+gh issue list --label "phase: X" --json state,title | jq '.[] | select(.state=="open")'
+
+# Métricas de progreso
+echo "Completadas: $(gh issue list --state closed | wc -l)"
+echo "Pendientes: $(gh issue list --state open | wc -l)"
+```
+
+## ✅ Criterios de Éxito
+
+- [ ] Todas las tareas de una fase completadas antes de pasar a la siguiente
+- [ ] Sin tareas bloqueadas sin resolver
+- [ ] Coverage global >80%
+- [ ] CI pasando en todas las ramas
+- [ ] Documentación actualizada por fase
+
+## 📚 Ejemplo de Uso
+
+```markdown
+**Input:**
+"Ejecuta el plan de desarrollo del Sports Dashboard siguiendo el documento maestro"
+
+**Proceso:**
+
+1. Leer FASE 0: Setup
+2. Crear issues TASK-001 a TASK-010
+3. Ejecutar TASK-001 con Setup Agent
+4. Al completar TASK-001, ejecutar TASK-002
+5. Continuar hasta completar FASE 0
+6. Merge develop → main
+7. Reportar: "FASE 0 completada: 10/10 tareas, 6.5h reales vs 8h estimadas"
+8. Iniciar FASE 1
+
+**Output:**
+
+- Issues creados y cerrados automáticamente
+- PRs mergeados
+- Reporte de progreso en tiempo real
+- Documentación actualizada
+```
+
+## 🚨 Manejo de Errores
+
+- **Dependencia bloqueada**: Saltar tarea, continuar con otras disponibles
+- **CI falla**: Detener fase, notificar, esperar corrección
+- **Conflicto de merge**: Notificar, resolver manualmente, continuar
+- **Timeout**: Si una tarea toma >2x estimación, escalar
+
+## 🔗 Skills Relacionadas
+
+- `task-planner` - Para descomponer tareas complejas
+- `github-flow-executor` - Para ejecutar el flujo de cada tarea
+- `milestone-tracker` - Para reportes de progreso

--- a/.claude/skills/orchestration/task-planner.md
+++ b/.claude/skills/orchestration/task-planner.md
@@ -1,0 +1,156 @@
+# Task Planner Skill
+
+## 📋 Descripción
+
+Descompone épicas en tareas atómicas con dependencias claras, criterios de aceptación y estimaciones.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Antes de iniciar una épica o feature compleja
+- Para planificar sprints
+- Cuando hay features con múltiples subtareas
+- Para crear el backlog inicial del proyecto
+
+## 🔄 Flujo de Planificación
+
+```
+1. ANALIZAR ÉPICA
+   ├─ Leer descripción y objetivos
+   ├─ Identificar funcionalidades principales
+   └─ Determinar alcance
+
+2. DESCOMPONER EN TAREAS
+   ├─ Dividir en tareas atómicas (1-4h cada una)
+   ├─ Asignar tipo (componente, hook, service, test, docs)
+   └─ Asignar agente especializado
+
+3. IDENTIFICAR DEPENDENCIAS
+   ├─ Tareas bloqueantes (deben completarse primero)
+   ├─ Tareas en paralelo (pueden ejecutarse simultáneamente)
+   └─ Crear grafo de dependencias
+
+4. DEFINIR CRITERIOS DE ACEPTACIÓN
+   ├─ Lista de checks por tarea
+   ├─ Métricas de calidad (coverage, tests)
+   └─ Entregables esperados
+
+5. ESTIMAR ESFUERZO
+   ├─ Tiempo estimado por tarea
+   ├─ Tiempo total de la épica
+   └─ Buffer para imprevistos (15-20%)
+
+6. GENERAR ISSUES
+   ├─ Crear issue por cada tarea
+   ├─ Usar template de GitHub
+   └─ Asignar labels y prioridades
+```
+
+## 📊 Template de Tarea
+
+```yaml
+ID: TASK-XXX
+Título: [Tipo] Descripción breve
+Tipo: component | hook | service | test | docs
+Agente: Component Agent | Hook Agent | Service Agent | Testing Agent | Docs Agent
+Prioridad: critical | high | medium | low
+Estimación: Xh
+Fase: 0-setup | 1-design-system | 2-hooks | 3-services | 4-features | 5-testing | 6-docs
+
+Descripción:
+  [Descripción detallada de qué se debe implementar]
+
+Criterios de Aceptación:
+  - [ ] Criterio 1
+  - [ ] Criterio 2
+  - [ ] Tests unitarios (coverage >80%)
+  - [ ] Documentación completa
+
+Dependencias:
+  - Depende de: #[issue_id]
+  - Bloquea a: #[issue_id]
+
+Tecnologías:
+  - React, TypeScript, Tailwind CSS
+  - Vitest, React Testing Library
+  - [Otras específicas]
+```
+
+## 📚 Ejemplo: Épica "Sistema de Scores"
+
+### Input
+
+```
+Épica: Implementar sistema de visualización de scores deportivos
+- Mostrar scores en tiempo real
+- Filtrar por liga
+- Ver detalle de partido
+```
+
+### Output
+
+**TASK-067: Crear componente ScoreBoard**
+
+- Tipo: component
+- Agente: Component Agent
+- Estimación: 2h
+- Dependencias: TASK-023 (ScoreCard), TASK-063 (useSportsScores)
+- Criterios:
+  - [ ] Componente con TypeScript
+  - [ ] Integración con useSportsScores hook
+  - [ ] Tests >80%
+  - [ ] Storybook story
+
+**TASK-068: Crear componente LiveScore**
+
+- Tipo: component
+- Agente: Component Agent
+- Estimación: 1.5h
+- Dependencias: TASK-023 (ScoreCard), TASK-066 (useLiveGames)
+- Criterios:
+  - [ ] Auto-refresh cada 30s
+  - [ ] Indicador de partido en vivo
+  - [ ] Tests >80%
+  - [ ] Storybook story
+
+**TASK-069: Crear componente ScoreList**
+
+- Tipo: component
+- Agente: Component Agent
+- Estimación: 1.5h
+- Dependencias: TASK-023 (ScoreCard)
+- Criterios:
+  - [ ] Paginación
+  - [ ] Filtrado por liga
+  - [ ] Tests >80%
+  - [ ] Storybook story
+
+**Total Estimado: 5h**
+**Dependencias Externas: TASK-023, TASK-063, TASK-066**
+
+## 🔧 Comandos
+
+```bash
+# Generar plan de tareas desde épica
+task-planner plan --epic "Sistema de Scores" --output tasks.yml
+
+# Crear issues en GitHub desde plan
+task-planner create-issues --file tasks.yml
+
+# Ver grafo de dependencias
+task-planner graph --file tasks.yml
+```
+
+## ✅ Checklist de Planificación
+
+- [ ] Épica dividida en tareas de 1-4h
+- [ ] Cada tarea tiene tipo y agente asignado
+- [ ] Dependencias identificadas
+- [ ] Criterios de aceptación definidos
+- [ ] Estimaciones realistas
+- [ ] Issues listos para crear en GitHub
+
+## 🔗 Skills Relacionadas
+
+- `project-orchestrator` - Ejecuta el plan generado
+- `issue-creator` - Crea issues desde el plan
+- `milestone-tracker` - Rastrea progreso del plan

--- a/.claude/skills/quality/code-reviewer.md
+++ b/.claude/skills/quality/code-reviewer.md
@@ -1,0 +1,396 @@
+# Code Reviewer Skill
+
+## 📋 Descripción
+
+Valida código contra los estándares del proyecto antes de aprobar PRs, verificando calidad, tests, accesibilidad, y mejores prácticas.
+
+## 🎯 Cuándo Usar Esta Skill
+
+- Revisar PRs antes de merge
+- Validar código antes de push
+- Code review automatizado en CI
+- Mentorship y pair programming
+
+## 🔍 Áreas de Review
+
+```
+1. CÓDIGO
+   ├─ TypeScript sin errores
+   ├─ ESLint sin warnings
+   ├─ Prettier formateado
+   ├─ No uso de 'any' injustificado
+   └─ Nombres descriptivos
+
+2. ARQUITECTURA
+   ├─ Estructura de carpetas correcta
+   ├─ Separación de responsabilidades
+   ├─ No duplicación de código
+   └─ Patrones consistentes
+
+3. TESTING
+   ├─ Tests unitarios presentes
+   ├─ Coverage >80%
+   ├─ Tests de edge cases
+   └─ Mocking apropiado
+
+4. ACCESIBILIDAD
+   ├─ ARIA labels
+   ├─ Roles semánticos
+   ├─ Navegación por teclado
+   └─ Contraste WCAG AA
+
+5. PERFORMANCE
+   ├─ No re-renders innecesarios
+   ├─ Uso de useMemo/useCallback
+   ├─ Lazy loading cuando aplique
+   └─ Bundle size razonable
+
+6. DOCUMENTACIÓN
+   ├─ JSDoc en funciones públicas
+   ├─ README actualizado
+   ├─ Storybook stories (componentes)
+   └─ Comentarios para lógica compleja
+
+7. SEGURIDAD
+   ├─ No secrets en código
+   ├─ Sanitización de inputs
+   ├─ Validación de datos
+   └─ Dependencias actualizadas
+```
+
+## ✅ Checklist de Review
+
+### Código Base
+
+```typescript
+// ❌ Malo: Type 'any' sin justificar
+function processData(data: any) {
+  return data.map((item: any) => item.value)
+}
+
+// ✅ Bueno: Tipos explícitos
+interface DataItem {
+  id: string
+  value: number
+}
+
+function processData(data: DataItem[]): number[] {
+  return data.map((item) => item.value)
+}
+```
+
+```typescript
+// ❌ Malo: Nombres no descriptivos
+const d = new Date()
+const x = d.getTime()
+const y = x / 1000
+
+// ✅ Bueno: Nombres descriptivos
+const currentDate = new Date()
+const currentTimestamp = currentDate.getTime()
+const currentTimestampInSeconds = currentTimestamp / 1000
+```
+
+### Componentes React
+
+```typescript
+// ❌ Malo: No usa forwardRef, no tiene className
+export function Button({ children, onClick }) {
+  return <button onClick={onClick}>{children}</button>;
+}
+
+// ✅ Bueno: forwardRef, props tipadas, className
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', children, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(buttonVariants({ variant }), className)}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';
+```
+
+### Hooks
+
+```typescript
+// ❌ Malo: No cleanup de side effects
+function useInterval(callback: () => void, delay: number) {
+  useEffect(() => {
+    const id = setInterval(callback, delay)
+    // ❌ Falta cleanup
+  }, [callback, delay])
+}
+
+// ✅ Bueno: Cleanup apropiado
+function useInterval(callback: () => void, delay: number) {
+  useEffect(() => {
+    const id = setInterval(callback, delay)
+    return () => clearInterval(id) // ✅ Cleanup
+  }, [callback, delay])
+}
+```
+
+```typescript
+// ❌ Malo: Callback no memoizado causa re-renders
+function Component() {
+  const handleClick = () => console.log('clicked');
+  return <Button onClick={handleClick} />;
+}
+
+// ✅ Bueno: Callback memoizado
+function Component() {
+  const handleClick = useCallback(() => {
+    console.log('clicked');
+  }, []);
+  return <Button onClick={handleClick} />;
+}
+```
+
+### Tests
+
+```typescript
+// ❌ Malo: Test vago sin assertions claras
+it('works', () => {
+  render(<Button />);
+  expect(screen.getByRole('button')).toBeTruthy();
+});
+
+// ✅ Bueno: Test específico con assertions claras
+it('calls onClick handler when clicked', async () => {
+  const user = userEvent.setup();
+  const handleClick = vi.fn();
+
+  render(<Button onClick={handleClick}>Click me</Button>);
+
+  await user.click(screen.getByRole('button', { name: /click me/i }));
+
+  expect(handleClick).toHaveBeenCalledTimes(1);
+});
+```
+
+### Accesibilidad
+
+```typescript
+// ❌ Malo: Sin ARIA labels
+function IconButton({ icon, onClick }) {
+  return <button onClick={onClick}>{icon}</button>;
+}
+
+// ✅ Bueno: Con ARIA label
+interface IconButtonProps {
+  icon: React.ReactNode;
+  onClick: () => void;
+  ariaLabel: string;
+}
+
+function IconButton({ icon, onClick, ariaLabel }: IconButtonProps) {
+  return (
+    <button onClick={onClick} aria-label={ariaLabel}>
+      {icon}
+    </button>
+  );
+}
+```
+
+## 🤖 Review Automatizado
+
+### Script de Pre-Review
+
+```bash
+#!/bin/bash
+# pre-review.sh
+
+echo "🔍 Running code review checks..."
+
+# 1. TypeScript
+echo "📘 Checking TypeScript..."
+npm run typecheck
+if [ $? -ne 0 ]; then
+  echo "❌ TypeScript errors found"
+  exit 1
+fi
+
+# 2. Linter
+echo "🔧 Running ESLint..."
+npm run lint
+if [ $? -ne 0 ]; then
+  echo "❌ ESLint errors found"
+  exit 1
+fi
+
+# 3. Tests
+echo "🧪 Running tests..."
+npm run test:run
+if [ $? -ne 0 ]; then
+  echo "❌ Tests failing"
+  exit 1
+fi
+
+# 4. Coverage
+echo "📊 Checking coverage..."
+COVERAGE=$(npm run test:coverage --silent | grep "All files" | awk '{print $4}')
+THRESHOLD=80
+
+if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
+  echo "❌ Coverage below $THRESHOLD% (got $COVERAGE%)"
+  exit 1
+fi
+
+echo "✅ All checks passed!"
+```
+
+## 📝 Template de Comentarios de Review
+
+### Solicitar Cambios
+
+````markdown
+## 🔍 Code Review
+
+### ❌ Issues Found
+
+#### 1. Missing Type Safety
+
+**File:** `src/components/Button.tsx:15`
+
+```typescript
+// Current
+function handleClick(data: any) { ... }
+
+// Suggested
+function handleClick(data: ButtonClickData) { ... }
+```
+````
+
+#### 2. Accessibility Issue
+
+**File:** `src/components/IconButton.tsx:8`
+
+```typescript
+// Missing aria-label for icon-only button
+<button onClick={onClick} aria-label="Close dialog">
+  <XIcon />
+</button>
+```
+
+#### 3. Missing Tests
+
+**File:** `src/hooks/useDebounce.test.ts`
+
+- [ ] Test cleanup on unmount
+- [ ] Test with rapidly changing values
+- [ ] Test custom delay parameter
+
+### 📊 Metrics
+
+- TypeScript Errors: 2
+- ESLint Warnings: 5
+- Test Coverage: 72% (target: 80%)
+- Missing Stories: Button, TextInput
+
+### 🎯 Action Items
+
+Please address the issues above and update coverage to meet the 80% threshold.
+
+````
+
+### Aprobar
+
+```markdown
+## ✅ Code Review - APPROVED
+
+### 👍 Highlights
+- Clean TypeScript implementation
+- Comprehensive test coverage (94%)
+- Excellent accessibility support
+- Well-documented with JSDoc
+
+### 📊 Metrics
+- TypeScript Errors: 0
+- ESLint Warnings: 0
+- Test Coverage: 94%
+- Storybook Stories: ✅
+
+### 💡 Minor Suggestions (non-blocking)
+- Consider extracting magic numbers to constants
+- Could memoize `calculateValue` function
+
+Great work! 🎉
+````
+
+## 🔧 Comandos de Review
+
+```bash
+# Ver cambios del PR
+gh pr diff
+
+# Ver archivos modificados
+gh pr view --json files --jq '.files[].path'
+
+# Comentar en línea específica
+gh pr review --comment --body "Consider extracting this to a constant"
+
+# Solicitar cambios
+gh pr review --request-changes --body "Please address TypeScript errors"
+
+# Aprobar
+gh pr review --approve --body "LGTM! Great work."
+
+# Ver estado del review
+gh pr checks
+```
+
+## 📊 Criterios de Aprobación
+
+| Criterio          | Obligatorio        | Target |
+| ----------------- | ------------------ | ------ |
+| TypeScript Errors | ✅                 | 0      |
+| ESLint Warnings   | ✅                 | 0      |
+| Test Coverage     | ✅                 | >80%   |
+| Tests Passing     | ✅                 | 100%   |
+| Storybook Stories | Si es componente   | ≥1     |
+| JSDoc             | Funciones públicas | 100%   |
+| WCAG AA           | Componentes UI     | 100%   |
+
+## 🎯 Red Flags
+
+⛔ **Bloquean el merge:**
+
+- TypeScript errors
+- ESLint errors
+- Tests failing
+- Coverage <80%
+- Security vulnerabilities
+- Missing tests para nueva funcionalidad
+
+⚠️ **Requieren discusión:**
+
+- Patrones no convencionales
+- Performance concerns
+- Architectural changes
+- Breaking changes sin documentar
+
+## 📚 Recursos de Referencia
+
+Durante el review, consultar:
+
+- `/docs/STANDARDS.md` - Convenciones del proyecto
+- `/docs/ARCHITECTURE.md` - Decisiones arquitectónicas
+- `/docs/COMPONENTS.md` - Guías de componentes
+- WCAG 2.1 Guidelines - Accesibilidad
+
+## 🔗 Skills Relacionadas
+
+- `test-coverage-validator` - Verificar cobertura
+- `accessibility-checker` - Validar a11y
+- `github-flow-executor` - Aprobar y mergear

--- a/.claude/skills/testing/accessibility-checker.md
+++ b/.claude/skills/testing/accessibility-checker.md
@@ -1,0 +1,84 @@
+# Accessibility Checker Skill
+
+## 📋 Descripción
+
+Valida accesibilidad de componentes UI contra WCAG 2.1 AA.
+
+## 🎯 Cuándo Usar
+
+- Después de crear un componente UI
+- Antes de aprobar PRs de componentes
+- Testing de accesibilidad
+
+## ✅ Validaciones
+
+### ARIA
+
+- [ ] Labels en inputs y botones
+- [ ] Roles semánticos correctos
+- [ ] Estados ARIA (aria-expanded, aria-disabled)
+- [ ] Relaciones ARIA (aria-describedby, aria-labelledby)
+
+### Teclado
+
+- [ ] Todos los elementos interactivos son focusables
+- [ ] Tab order lógico
+- [ ] Enter/Space activan botones
+- [ ] Escape cierra modals/dropdowns
+
+### Contraste (WCAG AA)
+
+- [ ] Texto normal: ratio ≥4.5:1
+- [ ] Texto grande: ratio ≥3:1
+- [ ] Elementos interactivos: ratio ≥3:1
+
+### Screen Readers
+
+- [ ] Contenido importante no está oculto
+- [ ] Imágenes tienen alt text
+- [ ] Formularios tienen labels asociados
+
+## 🔧 Herramientas
+
+```bash
+# axe-core en tests
+import { axe } from 'jest-axe';
+
+it('has no accessibility violations', async () => {
+  const { container } = render(<Button>Click me</Button>);
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});
+
+# Storybook addon-a11y
+# Automáticamente valida en cada story
+```
+
+## 📊 Checklist por Componente
+
+```typescript
+// Button.a11y.test.tsx
+describe('Button Accessibility', () => {
+  it('has no axe violations', async () => {
+    const { container } = render(<Button>Click</Button>);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has accessible name', () => {
+    render(<IconButton icon={<X />} ariaLabel="Close" />);
+    expect(screen.getByRole('button')).toHaveAccessibleName('Close');
+  });
+
+  it('has proper focus indicators', () => {
+    render(<Button>Focus me</Button>);
+    const button = screen.getByRole('button');
+    button.focus();
+    expect(button).toHaveFocus();
+  });
+});
+```
+
+## 🔗 Skills Relacionadas
+
+- `component-builder` - Aplica a11y desde el inicio
+- `code-reviewer` - Valida a11y en PRs

--- a/.claude/skills/testing/test-coverage-validator.md
+++ b/.claude/skills/testing/test-coverage-validator.md
@@ -1,0 +1,34 @@
+# Test Coverage Validator Skill
+
+## 📋 Descripción
+
+Verifica que la cobertura de tests cumpla con los umbrales del proyecto.
+
+## 🎯 Cuándo Usar
+
+- En CI antes de merge
+- Después de escribir tests
+- Para validar PRs
+
+## 📊 Umbrales
+
+| Tipo        | Target  | Mínimo  |
+| ----------- | ------- | ------- |
+| Componentes | 80%     | 70%     |
+| Hooks       | 90%     | 80%     |
+| Services    | 85%     | 75%     |
+| Utils       | 95%     | 90%     |
+| **Global**  | **80%** | **75%** |
+
+## 🔧 Comandos
+
+```bash
+# Ver coverage
+npm run test:coverage
+
+# Coverage de archivo específico
+npm run test:coverage -- Button.test.tsx
+
+# Fallar si coverage < 80%
+npm run test:coverage -- --coverage.thresholds.global.lines=80
+```

--- a/.claude/skills/testing/test-generator.md
+++ b/.claude/skills/testing/test-generator.md
@@ -1,0 +1,39 @@
+# Test Generator Skill
+
+## 📋 Descripción
+
+Genera tests unitarios exhaustivos con alta cobertura siguiendo los patrones del proyecto.
+
+## 🎯 Cuándo Usar
+
+- Después de implementar componente/hook/service
+- Para garantizar coverage >80%
+- Generar tests de edge cases
+
+## 📝 Template de Tests
+
+```typescript
+describe('ComponentName', () => {
+  describe('Rendering', () => {
+    it('renders with default props', () => {})
+    it('renders all variants correctly', () => {})
+  })
+
+  describe('Interactions', () => {
+    it('calls onClick when clicked', async () => {})
+    it('does not call onClick when disabled', async () => {})
+  })
+
+  describe('Accessibility', () => {
+    it('is focusable via keyboard', async () => {})
+    it('can be activated with Enter key', async () => {})
+  })
+})
+```
+
+## ✅ Coverage Target
+
+- Componentes: >80%
+- Hooks: >90%
+- Services: >85%
+- Utils: >95%

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # Sports API
 # Base URL for the sports data API
-VITE_API_BASE_URL=https://api.sportsdata.example.com/v1
+VITE_API_BASE_URL=https://v3.football.api-sports.io
 
 # API Key for authentication (if required)
-VITE_API_KEY=your_api_key_here
+VITE_API_KEY=MY_APY_KEY
 
 # Request timeout in milliseconds
 VITE_API_TIMEOUT=15000


### PR DESCRIPTION
## Summary
Adds the `.claude/` directory with specialized skills and execution guides for the Claude Code agent workflow.

## Files added (22 files)

### Guide
- `.claude/guides/EXECUTION_GUIDE.md` — instructions for running the full development plan with Claude Code

### Skills (21 files across 7 domains)
| Domain | Skills |
|---|---|
| design | design-reader-mcp, design-system-builder, tailwind-composer |
| development | component-builder, hook-builder, service-builder |
| documentation | architecture-documenter, jsdoc-generator, storybook-story-generator |
| github | conventional-commits, github-flow-executor, issue-creator, pr-creator |
| orchestration | milestone-tracker, project-orchestrator, task-planner |
| quality | code-reviewer |
| testing | accessibility-checker, test-coverage-validator, test-generator |

## Test plan
- [x] No code changes — documentation only
- [x] Markdown files formatted by Prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)